### PR TITLE
add appCatalog CRD on running 

### DIFF
--- a/service/controller/app.go
+++ b/service/controller/app.go
@@ -26,6 +26,7 @@ type Config struct {
 
 type App struct {
 	*controller.Controller
+	*k8scrdclient.CRDClient
 }
 
 func NewApp(config Config) (*App, error) {
@@ -114,6 +115,7 @@ func NewApp(config Config) (*App, error) {
 
 	c := &App{
 		Controller: appController,
+		CRDClient:  crdClient,
 	}
 
 	return c, nil


### PR DESCRIPTION
After running operator, new 2 CRDs will be created inside k8s.
`> kubectl get crd`

```
NAME                                    AGE
appcatalogs.application.giantswarm.io   1m
apps.application.giantswarm.io          1d
```
The pain point in here: 
Currently, all our operator structures only allow you to create one CRD at operator booting time.  
But app-operator itself have to create two new CRDs, which have to make the code a bit dirty to make it works. 

Why dirty?: 
I stored `CRDClient` instance in `app` instance which only supposed to be stored in `controller`,
so I can run it inside `Service.Boot` method.


I'm not sure that this approach is the best practice so please let me know if it's not!