### PR TITLE
Add configmap resource with current state

### DIFF
--- a/service/controller/app/v1/controllercontext/context.go
+++ b/service/controller/app/v1/controllercontext/context.go
@@ -13,8 +13,8 @@ type contextKey string
 const controllerKey contextKey = "controller"
 
 type Context struct {
-	G8sClient  versioned.Interface
-	K8sClient  kubernetes.Interface
+	G8sClient versioned.Interface
+	K8sClient kubernetes.Interface
 }
 
 func NewContext(ctx context.Context, c Context) context.Context {

--- a/service/controller/app/v1/controllercontext/context.go
+++ b/service/controller/app/v1/controllercontext/context.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
+	"k8s.io/client-go/kubernetes"
 )
 
 type contextKey string
@@ -12,7 +13,8 @@ type contextKey string
 const controllerKey contextKey = "controller"
 
 type Context struct {
-	G8sClient versioned.Interface
+	G8sClient  versioned.Interface
+	K8sClient  kubernetes.Interface
 }
 
 func NewContext(ctx context.Context, c Context) context.Context {

--- a/service/controller/app/v1/resource/configmap/current.go
+++ b/service/controller/app/v1/resource/configmap/current.go
@@ -19,7 +19,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	name := key.ConfigMapName(cr)
-	namespace := key.ConfigMapNamespace(cr)
+	namespace := key.Namespace(cr)
 
 	ctlCtx, err := controllercontext.FromContext(ctx)
 	if err != nil {

--- a/service/controller/app/v1/resource/configmap/current.go
+++ b/service/controller/app/v1/resource/configmap/current.go
@@ -1,0 +1,43 @@
+package configmap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
+	"github.com/giantswarm/app-operator/service/controller/app/v1/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	cr, err := key.ToCustomResource(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	name := key.ConfigMapName(cr)
+	namespace := key.ConfigMapNamespace(cr)
+
+	ctlCtx, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding configmap %#q", name))
+
+	chart, err := ctlCtx.K8sClient.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		// Return early as configmap does not exist.
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find configmap %#q", name))
+		return nil, nil
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found configmap %#q", name))
+
+	return chart, nil
+}

--- a/service/controller/app/v1/resource/configmap/current_test.go
+++ b/service/controller/app/v1/resource/configmap/current_test.go
@@ -1,0 +1,147 @@
+package configmap
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/micrologger/microloggertest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
+)
+
+func Test_Resource_GetCurrentState(t *testing.T) {
+	tests := []struct {
+		name              string
+		obj               *v1alpha1.App
+		configMap         *corev1.ConfigMap
+		expectedConfigMap *corev1.ConfigMap
+		errorMatcher      func(error) bool
+	}{
+		{
+			name: "case 0: basic match",
+			obj: &v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "app-values",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			configMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"key": "value",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "app-values",
+					Namespace: "default",
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"key": "value",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "app-values",
+					Namespace: "default",
+				},
+			},
+		},
+		{
+			name: "case 1: no matching configmap",
+			obj: &v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "app-values",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			configMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"key": "value",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-app-values",
+					Namespace: "default",
+				},
+			},
+		},
+		{
+			name: "case 2: no configmaps",
+			obj: &v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "app-values",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := make([]runtime.Object, 0, 0)
+			if tc.configMap != nil {
+				objs = append(objs, tc.configMap)
+			}
+
+			g8sClient := fake.NewSimpleClientset()
+			k8sClient := clientgofake.NewSimpleClientset(objs...)
+
+			var ctx context.Context
+			{
+				c := controllercontext.Context{
+					G8sClient: g8sClient,
+					K8sClient: k8sClient,
+				}
+				ctx = controllercontext.NewContext(context.Background(), c)
+			}
+
+			c := Config{
+				G8sClient: g8sClient,
+				K8sClient: k8sClient,
+				Logger:    microloggertest.New(),
+
+				ProjectName:    "app-operator",
+				WatchNamespace: "default",
+			}
+			r, err := New(c)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			result, err := r.GetCurrentState(ctx, tc.obj)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			configMap, err := toConfigMap(result)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			if !reflect.DeepEqual(configMap, tc.expectedConfigMap) {
+				t.Fatalf("configMap == %q, want %q", configMap, tc.expectedConfigMap)
+			}
+		})
+	}
+}

--- a/service/controller/app/v1/resource/configmap/error.go
+++ b/service/controller/app/v1/resource/configmap/error.go
@@ -1,0 +1,21 @@
+package configmap
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/app/v1/resource/configmap/resource.go
+++ b/service/controller/app/v1/resource/configmap/resource.go
@@ -1,11 +1,12 @@
 package configmap
 
 import (
-	"reflect"
+	"context"
 
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -73,35 +74,32 @@ func New(config Config) (*Resource, error) {
 	return r, nil
 }
 
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}
+
 func (r *Resource) Name() string {
 	return Name
 }
 
-// equals asseses the equality of ConfigMaps with regards to distinguishing
-// fields.
-func equals(a, b *corev1.ConfigMap) bool {
-	if a.Name != b.Name {
-		return false
-	}
-	if a.Namespace != b.Namespace {
-		return false
-	}
-	if !reflect.DeepEqual(a.Annotations, b.Annotations) {
-		return false
-	}
-	if !reflect.DeepEqual(a.Data, b.Data) {
-		return false
-	}
-	if !reflect.DeepEqual(a.Labels, b.Labels) {
-		return false
-	}
-
-	return true
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	return nil, nil
 }
 
-// isEmpty checks if a ConfigMap is empty.
-func isEmpty(c *corev1.ConfigMap) bool {
-	return equals(c, &corev1.ConfigMap{})
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	return nil, nil
 }
 
 // toConfigMap converts the input into a ConfigMap.

--- a/service/controller/app/v1/resource/configmap/resource.go
+++ b/service/controller/app/v1/resource/configmap/resource.go
@@ -1,0 +1,119 @@
+package configmap
+
+import (
+	"reflect"
+
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "configmapv1"
+
+	// valuesKey is the data key when getting values from a configmap.
+	valuesKey = "values"
+)
+
+// Config represents the configuration used to create a new configmap resource.
+type Config struct {
+	// Dependencies.
+	G8sClient versioned.Interface
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+
+	// Settings.
+	ProjectName    string
+	WatchNamespace string
+}
+
+// Resource implements the configmap resource.
+type Resource struct {
+	// Dependencies.
+	g8sClient versioned.Interface
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+
+	// Settings.
+	projectName    string
+	watchNamespace string
+}
+
+// New creates a new configured configmap resource.
+func New(config Config) (*Resource, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
+	}
+	if config.WatchNamespace == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.WatchNamespace must not be empty", config)
+	}
+
+	r := &Resource{
+		g8sClient: config.G8sClient,
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+
+		projectName:    config.ProjectName,
+		watchNamespace: config.WatchNamespace,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+// equals asseses the equality of ConfigMaps with regards to distinguishing
+// fields.
+func equals(a, b *corev1.ConfigMap) bool {
+	if a.Name != b.Name {
+		return false
+	}
+	if a.Namespace != b.Namespace {
+		return false
+	}
+	if !reflect.DeepEqual(a.Annotations, b.Annotations) {
+		return false
+	}
+	if !reflect.DeepEqual(a.Data, b.Data) {
+		return false
+	}
+	if !reflect.DeepEqual(a.Labels, b.Labels) {
+		return false
+	}
+
+	return true
+}
+
+// isEmpty checks if a ConfigMap is empty.
+func isEmpty(c *corev1.ConfigMap) bool {
+	return equals(c, &corev1.ConfigMap{})
+}
+
+// toConfigMap converts the input into a ConfigMap.
+func toConfigMap(v interface{}) (*corev1.ConfigMap, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	configMap, ok := v.(*corev1.ConfigMap)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &corev1.ConfigMap{}, v)
+	}
+
+	return configMap, nil
+}

--- a/service/controller/app/v1/resource_set.go
+++ b/service/controller/app/v1/resource_set.go
@@ -15,6 +15,7 @@ import (
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/key"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/resource/chart"
+	"github.com/giantswarm/app-operator/service/controller/app/v1/resource/configmap"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/resource/status"
 )
 
@@ -109,6 +110,28 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
+	var configMapResource controller.Resource
+	{
+		c := configmap.Config{
+			G8sClient: config.G8sClient,
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			ProjectName:    config.ProjectName,
+			WatchNamespace: config.WatchNamespace,
+		}
+
+		ops, err := configmap.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMapResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []controller.Resource{
 		chartResource,
 		chartStatusResource,
@@ -144,8 +167,14 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			return nil, microerror.Mask(err)
 		}
 
+		k8sClient, err := kubeConfig.NewK8sClientForApp(ctx, cr)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
 		c := controllercontext.Context{
 			G8sClient: g8sClient,
+			K8sClient: k8sClient,
 		}
 		ctx = controllercontext.NewContext(ctx, c)
 

--- a/service/controller/app/v1/resource_set.go
+++ b/service/controller/app/v1/resource_set.go
@@ -133,6 +133,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	}
 
 	resources := []controller.Resource{
+		configMapResource,
 		chartResource,
 		chartStatusResource,
 	}

--- a/service/controller/appcatalog/v1/key/key.go
+++ b/service/controller/appcatalog/v1/key/key.go
@@ -15,6 +15,14 @@ func AppCatalogStorageURL(customResource v1alpha1.AppCatalog) string {
 	return customResource.Spec.Storage.URL
 }
 
+func ConfigMapName(customResource v1alpha1.AppCatalog) string {
+	return customResource.Spec.Config.ConfigMap.Name
+}
+
+func ConfigMapNamespace(customResource v1alpha1.AppCatalog) string {
+	return customResource.Spec.Config.ConfigMap.Namespace
+}
+
 // ToCustomResource converts value to v1alpha1.AppCatalog and returns it or error
 // if type does not match.
 func ToCustomResource(v interface{}) (v1alpha1.AppCatalog, error) {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4845

Adds the configmap resource which generates configmaps for use by chart-operator.