### PR TITLE
Remove unused circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,17 +61,3 @@ workflows:
       - e2eTestChartInstall:
           requires:
             - build
-
-      - deploy:
-          filters:
-            branches:
-              only: master
-          requires:
-            - e2eTestChartInstall
-
-      - publish_to_stable:
-          filters:
-            branches:
-              only: master
-          requires:
-            - deploy


### PR DESCRIPTION
Currently CI is red on merge to master. Looks like some copy pasta from chart-operator.

Simplifying to just have what we use now. We still need to have app-operator installed in control planes with draughtsman. I plan to set that up next week.