### PR TITLE
Fix RBAC error

### DIFF
--- a/helm/app-operator-chart/templates/configmap.yaml
+++ b/helm/app-operator-chart/templates/configmap.yaml
@@ -15,8 +15,6 @@ data:
       listen:
         address: 'http://0.0.0.0:{{ .Values.port }}'
     service:
-      helm:
-        tillerNamespace:  '{{ .Values.namespace }}'
       kubernetes:
         incluster: true
         watch:

--- a/helm/app-operator-chart/templates/rbac.yaml
+++ b/helm/app-operator-chart/templates/rbac.yaml
@@ -36,14 +36,7 @@ rules:
   verbs:
     - get
     - list
-    - watch
-- apiGroups:
-    - application.giantswarm.io
-  resources:
-    - apps
-  verbs:
-    - get
-    - list
+    - patch
     - watch
 - apiGroups:
   - "rbac.authorization.k8s.io"


### PR DESCRIPTION
Adds patch support to appcatalog so operatorkit can add the finalizer.
```
E 02/25 17:10:35 /apis/application.giantswarm.io/v1alpha1/appcatalogs/sample-catalog stop reconciliation due to error | operatorkit/controller/controller.go:356 | controller=app-operator | event=update | loop=2 | version=59319983
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/finalizer.go:80:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/finalizer.go:70:
	appcatalogs.application.giantswarm.io "sample-catalog" is forbidden: User "system:serviceaccount:giantswarm:app-operator" cannot patch resource "appcatalogs" in API group "application.giantswarm.io" at the cluster scope
```

Also tidies up a couple of other issues with the YAML.