### PR TITLE
Add permissions to manage configmaps

### DIFF
--- a/helm/app-operator-chart/templates/rbac.yaml
+++ b/helm/app-operator-chart/templates/rbac.yaml
@@ -63,6 +63,12 @@ rules:
   - deployments
   verbs:
   - 'create'
+ - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - "*"
 - nonResourceURLs:
   - "/"
   - "/healthz"

--- a/helm/app-operator-chart/templates/rbac.yaml
+++ b/helm/app-operator-chart/templates/rbac.yaml
@@ -63,7 +63,7 @@ rules:
   - deployments
   verbs:
   - 'create'
- - apiGroups:
+- apiGroups:
   - ""
   resources:
   - configmaps


### PR DESCRIPTION
Adds RBAC permissions for the index resource. This caches the index.yaml so it can be served by the API.

The operator will also need these permissions for the configmap resource.

```
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:64:
	/go/src/github.com/giantswarm/app-operator/service/controller/appcatalog/v1/resource/index/current.go:29:
	configmaps "sample-catalog-index" is forbidden: User "system:serviceaccount:giantswarm:app-operator" cannot get resource "configmaps" in API group "" in the namespace "giantswarm"
D 02/26 11:48:26 /apis/application.giantswarm.io/v1alpha1/appcatalogs/sample-catalog indexv1.GetCurrentState finding index configMap `sample-catalog-index` | app-operator/service/controller/appcatalog/v1/resource/index/current.go:22 | controller=app-operator | event=update | loop=1 | version=103887126
```