### PR TITLE
Add test for service creation and updated catalog index flag

### DIFF
--- a/flag/service/appcatalog/appcatalog.go
+++ b/flag/service/appcatalog/appcatalog.go
@@ -1,6 +1,10 @@
 package appcatalog
 
+import (
+	"github.com/giantswarm/app-operator/flag/service/appcatalog/index"
+)
+
 // AppCatalog is a data structure to hold AppCatalog specific command line configuration flags.
 type AppCatalog struct {
-	IndexNamespace string
+	Index index.Index
 }

--- a/flag/service/appcatalog/index/index.go
+++ b/flag/service/appcatalog/index/index.go
@@ -1,0 +1,7 @@
+package index
+
+// Index is a data structure to hold Index specific
+// configuration.
+type Index struct {
+	Namespace string
+}

--- a/helm/app-operator-chart/templates/configmap.yaml
+++ b/helm/app-operator-chart/templates/configmap.yaml
@@ -15,6 +15,9 @@ data:
       listen:
         address: 'http://0.0.0.0:{{ .Values.port }}'
     service:
+      appcatalog:
+        index:
+          namespace: '{{ .Values.namespace }}'
       kubernetes:
         incluster: true
         watch:

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func mainWithError() (err error) {
 
 	daemonCommand := newCommand.DaemonCommand().CobraCommand()
 
-	daemonCommand.PersistentFlags().String(f.Service.AppCatalog.IndexNamespace, "giantswarm", "The namespace where operator keep index file as configMap.")
+	daemonCommand.PersistentFlags().String(f.Service.AppCatalog.Index.Namespace, "giantswarm", "The namespace where operator keep index file as configMap.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "", "Address used to connect to Kubernetes. When empty in-cluster config is created.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Kubernetes.InCluster, true, "Whether to use the in-cluster config to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CAFile, "", "Certificate authority file path to use to authenticate with Kubernetes.")

--- a/service/service.go
+++ b/service/service.go
@@ -98,7 +98,7 @@ func New(config Config) (*Service, error) {
 			K8sClient:    k8sClient,
 			K8sExtClient: k8sExtClient,
 
-			IndexNamespace: config.Viper.GetString(config.Flag.Service.AppCatalog.IndexNamespace),
+			IndexNamespace: config.Viper.GetString(config.Flag.Service.AppCatalog.Index.Namespace),
 			ProjectName:    config.ProjectName,
 			WatchNamespace: config.Viper.GetString(config.Flag.Service.Kubernetes.Watch.Namespace),
 		}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/spf13/viper"
+
+	"github.com/giantswarm/app-operator/flag"
+)
+
+func Test_Service_New(t *testing.T) {
+	testCases := []struct {
+		name         string
+		config       func() Config
+		errorMatcher func(error) bool
+	}{
+		{
+			name: "case 0: valid config returns no error",
+			config: func() Config {
+				c := Config{
+					Flag:   flag.New(),
+					Logger: microloggertest.New(),
+					Viper:  viper.New(),
+
+					Description: "test",
+					GitCommit:   "test",
+					ProjectName: "chart-operator",
+					Source:      "test",
+				}
+
+				c.Viper.Set(c.Flag.Service.AppCatalog.Index.Namespace, "giantswarm")
+				c.Viper.Set(c.Flag.Service.Kubernetes.Address, "kubernetes")
+				c.Viper.Set(c.Flag.Service.Kubernetes.InCluster, false)
+				c.Viper.Set(c.Flag.Service.Kubernetes.Watch.Namespace, "giantswarm")
+
+				return c
+			},
+			errorMatcher: nil,
+		},
+		{
+			name: "case 1: invalid config returns error",
+			config: func() Config {
+				c := Config{
+					Flag:  flag.New(),
+					Viper: viper.New(),
+				}
+
+				return c
+			},
+			errorMatcher: IsInvalidConfig,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := New(tc.config())
+
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case tc.errorMatcher != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a test for service creation to make sure all necessary flags are set.

I'd missed the k8s client from the configmap resource which caused the operator to crash when deployed to a test install.

Also renames `f.Service.AppCatalog.IndexNamespace` to `f.Service.AppCatalog.Index.Namespace` to align with `f.Service.Kubernetes.Watch.Namespace`.
