### PR TITLE
Updated namespace handling in chart resource

### DIFF
--- a/flag/service/chart/chart.go
+++ b/flag/service/chart/chart.go
@@ -1,0 +1,7 @@
+package chart
+
+// Chart is a data structure to hold Chart custom resource specific
+// configuration.
+type Chart struct {
+	Namespace string
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -2,11 +2,13 @@ package service
 
 import (
 	"github.com/giantswarm/app-operator/flag/service/appcatalog"
+	"github.com/giantswarm/app-operator/flag/service/chart"
 	"github.com/giantswarm/app-operator/flag/service/kubernetes"
 )
 
 // Service is an intermediate data structure for command line configuration flags.
 type Service struct {
 	AppCatalog appcatalog.AppCatalog
+	Chart      chart.Chart
 	Kubernetes kubernetes.Kubernetes
 }

--- a/main.go
+++ b/main.go
@@ -106,6 +106,7 @@ func mainWithError() (err error) {
 	daemonCommand := newCommand.DaemonCommand().CobraCommand()
 
 	daemonCommand.PersistentFlags().String(f.Service.AppCatalog.Index.Namespace, "giantswarm", "The namespace where operator keep index file as configMap.")
+	daemonCommand.PersistentFlags().String(f.Service.Chart.Namespace, "giantswarm", "The namespace where chart CRs are located.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "", "Address used to connect to Kubernetes. When empty in-cluster config is created.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Kubernetes.InCluster, true, "Whether to use the in-cluster config to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CAFile, "", "Certificate authority file path to use to authenticate with Kubernetes.")

--- a/service/controller/app/app.go
+++ b/service/controller/app/app.go
@@ -11,7 +11,7 @@ import (
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/giantswarm/app-operator/service/controller/app/v1"
+	v1 "github.com/giantswarm/app-operator/service/controller/app/v1"
 )
 
 type Config struct {
@@ -20,6 +20,7 @@ type Config struct {
 	K8sExtClient apiextensionsclient.Interface
 	Logger       micrologger.Logger
 
+	ChartNamespace string
 	ProjectName    string
 	WatchNamespace string
 }
@@ -80,6 +81,7 @@ func NewApp(config Config) (*App, error) {
 	var resourceSetV1 *controller.ResourceSet
 	{
 		c := v1.ResourceSetConfig{
+			ChartNamespace: config.ChartNamespace,
 			G8sClient:      config.G8sClient,
 			K8sClient:      config.K8sClient,
 			Logger:         config.Logger,

--- a/service/controller/app/app.go
+++ b/service/controller/app/app.go
@@ -11,7 +11,7 @@ import (
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 
-	v1 "github.com/giantswarm/app-operator/service/controller/app/v1"
+	"github.com/giantswarm/app-operator/service/controller/app/v1"
 )
 
 type Config struct {

--- a/service/controller/app/v1/resource/chart/create.go
+++ b/service/controller/app/v1/resource/chart/create.go
@@ -29,7 +29,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			return microerror.Mask(err)
 		}
 
-		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.ObjectMeta.Namespace).Create(&chart)
+		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.GetNamespace()).Create(&chart)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/app/v1/resource/chart/create.go
+++ b/service/controller/app/v1/resource/chart/create.go
@@ -29,7 +29,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			return microerror.Mask(err)
 		}
 
-		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.Namespace).Create(&chart)
+		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.ObjectMeta.Namespace).Create(&chart)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/app/v1/resource/chart/create_test.go
+++ b/service/controller/app/v1/resource/chart/create_test.go
@@ -100,6 +100,7 @@ func Test_Resource_newCreateChange(t *testing.T) {
 		G8sClient: fake.NewSimpleClientset(),
 		Logger:    microloggertest.New(),
 
+		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
 		WatchNamespace: "default",
 	}

--- a/service/controller/app/v1/resource/chart/current.go
+++ b/service/controller/app/v1/resource/chart/current.go
@@ -27,7 +27,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding chart %#q", name))
 
-	chart, err := cc.G8sClient.ApplicationV1alpha1().Charts(r.watchNamespace).Get(name, metav1.GetOptions{})
+	chart, err := cc.G8sClient.ApplicationV1alpha1().Charts(r.chartNamespace).Get(name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find chart %#q", name))
 		return nil, nil

--- a/service/controller/app/v1/resource/chart/current_test.go
+++ b/service/controller/app/v1/resource/chart/current_test.go
@@ -137,6 +137,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 				G8sClient: g8sClient,
 				Logger:    microloggertest.New(),
 
+				ChartNamespace: "giantswarm",
 				ProjectName:    "app-operator",
 				WatchNamespace: "default",
 			}

--- a/service/controller/app/v1/resource/chart/delete.go
+++ b/service/controller/app/v1/resource/chart/delete.go
@@ -31,7 +31,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			return microerror.Mask(err)
 		}
 
-		err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.ObjectMeta.Namespace).Delete(chart.Name, &metav1.DeleteOptions{})
+		err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.GetNamespace()).Delete(chart.Name, &metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			// fall through
 		} else if err != nil {

--- a/service/controller/app/v1/resource/chart/delete.go
+++ b/service/controller/app/v1/resource/chart/delete.go
@@ -31,7 +31,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			return microerror.Mask(err)
 		}
 
-		err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.Namespace).Delete(chart.Name, &metav1.DeleteOptions{})
+		err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.ObjectMeta.Namespace).Delete(chart.Name, &metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			// fall through
 		} else if err != nil {

--- a/service/controller/app/v1/resource/chart/delete_test.go
+++ b/service/controller/app/v1/resource/chart/delete_test.go
@@ -116,6 +116,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 		G8sClient: fake.NewSimpleClientset(),
 		Logger:    microloggertest.New(),
 
+		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
 		WatchNamespace: "default",
 	}

--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -39,6 +39,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cr.Spec.Name,
+			Namespace:   r.chartNamespace,
 			Labels:      processLabels(r.projectName, cr.ObjectMeta.Labels),
 			Annotations: cr.ObjectMeta.Annotations,
 		},

--- a/service/controller/app/v1/resource/chart/desired_test.go
+++ b/service/controller/app/v1/resource/chart/desired_test.go
@@ -82,7 +82,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					APIVersion: "application.giantswarm.io",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "prometheus",
+					Name:      "prometheus",
+					Namespace: "giantswarm",
 					Labels: map[string]string{
 						"app":                                  "prometheus",
 						"chart-operator.giantswarm.io/version": "1.0.0",

--- a/service/controller/app/v1/resource/chart/desired_test.go
+++ b/service/controller/app/v1/resource/chart/desired_test.go
@@ -171,6 +171,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				G8sClient: fake.NewSimpleClientset(),
 				Logger:    microloggertest.New(),
 
+				ChartNamespace: "giantswarm",
 				ProjectName:    "app-operator",
 				WatchNamespace: "default",
 			}

--- a/service/controller/app/v1/resource/chart/resource.go
+++ b/service/controller/app/v1/resource/chart/resource.go
@@ -25,6 +25,7 @@ type Config struct {
 	Logger    micrologger.Logger
 
 	// Settings.
+	ChartNamespace string
 	ProjectName    string
 	WatchNamespace string
 }
@@ -36,6 +37,7 @@ type Resource struct {
 	logger    micrologger.Logger
 
 	// Settings.
+	chartNamespace string
 	projectName    string
 	watchNamespace string
 }
@@ -49,6 +51,9 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
+	if config.ChartNamespace == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ChartNamespace must not be empty", config)
+	}
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
 	}
@@ -60,6 +65,7 @@ func New(config Config) (*Resource, error) {
 		g8sClient: config.G8sClient,
 		logger:    config.Logger,
 
+		chartNamespace: config.ChartNamespace,
 		projectName:    config.ProjectName,
 		watchNamespace: config.WatchNamespace,
 	}

--- a/service/controller/app/v1/resource/chart/update.go
+++ b/service/controller/app/v1/resource/chart/update.go
@@ -3,6 +3,7 @@ package chart
 import (
 	"context"
 	"fmt"
+
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 
 	"github.com/giantswarm/microerror"
@@ -48,7 +49,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			return microerror.Mask(err)
 		}
 
-		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.Namespace).Update(&chart)
+		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.ObjectMeta.Namespace).Update(&chart)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/app/v1/resource/chart/update.go
+++ b/service/controller/app/v1/resource/chart/update.go
@@ -49,7 +49,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			return microerror.Mask(err)
 		}
 
-		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.ObjectMeta.Namespace).Update(&chart)
+		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.GetNamespace()).Update(&chart)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/app/v1/resource/chart/update_test.go
+++ b/service/controller/app/v1/resource/chart/update_test.go
@@ -116,6 +116,7 @@ func Test_Resource_newUpdateChange(t *testing.T) {
 		G8sClient: fake.NewSimpleClientset(),
 		Logger:    microloggertest.New(),
 
+		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
 		WatchNamespace: "default",
 	}

--- a/service/controller/app/v1/resource_set.go
+++ b/service/controller/app/v1/resource_set.go
@@ -28,9 +28,9 @@ type ResourceSetConfig struct {
 	Logger    micrologger.Logger
 
 	// Settings.
-	HandledVersionBundles []string
-	ProjectName           string
-	WatchNamespace        string
+	ChartNamespace string
+	ProjectName    string
+	WatchNamespace string
 }
 
 // NewResourceSet returns a configured App controller ResourceSet.
@@ -49,6 +49,9 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	}
 
 	// Settings.
+	if config.ChartNamespace == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ChartNamespace must not be empty", config)
+	}
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
 	}
@@ -90,6 +93,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			G8sClient: config.G8sClient,
 			Logger:    config.Logger,
 
+			ChartNamespace: config.ChartNamespace,
 			ProjectName:    config.ProjectName,
 			WatchNamespace: config.WatchNamespace,
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -117,6 +117,7 @@ func New(config Config) (*Service, error) {
 			K8sClient:    k8sClient,
 			K8sExtClient: k8sExtClient,
 
+			ChartNamespace: config.Viper.GetString(config.Flag.Service.Chart.Namespace),
 			ProjectName:    config.ProjectName,
 			WatchNamespace: config.Viper.GetString(config.Flag.Service.Kubernetes.Watch.Namespace),
 		}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -29,6 +29,7 @@ func Test_Service_New(t *testing.T) {
 					Source:      "test",
 				}
 
+				c.Viper.Set(c.Flag.Service.Chart.Namespace, "giantswarm")
 				c.Viper.Set(c.Flag.Service.AppCatalog.Index.Namespace, "giantswarm")
 				c.Viper.Set(c.Flag.Service.Kubernetes.Address, "kubernetes")
 				c.Viper.Set(c.Flag.Service.Kubernetes.InCluster, false)


### PR DESCRIPTION
Adds new flag for the namespace chart CRs should be created in. Currently the namespace in the app CR is used but this is incorrect.

e.g. App namespace for coredns will be kube-system but the chart CR should be created in the giantswarm namespace.