### PR TITLE
Rename key.ToChart to toChart

### DIFF
--- a/service/controller/app/v1/key/key.go
+++ b/service/controller/app/v1/key/key.go
@@ -84,18 +84,6 @@ func ToCustomResource(v interface{}) (v1alpha1.App, error) {
 	return *customResource, nil
 }
 
-func ToChart(v interface{}) (v1alpha1.Chart, error) {
-	if v == nil {
-		return v1alpha1.Chart{}, nil
-	}
-	customResource, ok := v.(*v1alpha1.Chart)
-	if !ok {
-		return v1alpha1.Chart{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.Chart{}, v)
-	}
-
-	return *customResource, nil
-}
-
 func Version(customResource v1alpha1.App) string {
 	return customResource.Spec.Version
 }

--- a/service/controller/app/v1/resource/chart/create.go
+++ b/service/controller/app/v1/resource/chart/create.go
@@ -17,7 +17,8 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	chart, err := key.ToChart(createChange)
+
+	chart, err := toChart(createChange)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -44,11 +45,11 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 }
 
 func (r *Resource) newCreateChange(ctx context.Context, currentResource, desiredResource interface{}) (interface{}, error) {
-	currentChart, err := key.ToChart(currentResource)
+	currentChart, err := toChart(currentResource)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-	desiredChart, err := key.ToChart(desiredResource)
+	desiredChart, err := toChart(desiredResource)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/app/v1/resource/chart/current_test.go
+++ b/service/controller/app/v1/resource/chart/current_test.go
@@ -13,7 +13,6 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
-	"github.com/giantswarm/app-operator/service/controller/app/v1/key"
 )
 
 func Test_Resource_GetCurrentState(t *testing.T) {
@@ -158,7 +157,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 
 			if err == nil && tc.errorMatcher == nil {
 				if result != nil {
-					chart, err := key.ToChart(result)
+					chart, err := toChart(result)
 					if err != nil {
 						t.Fatalf("error == %#v, want nil", err)
 					}

--- a/service/controller/app/v1/resource/chart/delete.go
+++ b/service/controller/app/v1/resource/chart/delete.go
@@ -18,7 +18,8 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	chart, err := key.ToChart(deleteChange)
+
+	chart, err := toChart(deleteChange)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -57,11 +58,11 @@ func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desire
 }
 
 func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	currentChart, err := key.ToChart(currentState)
+	currentChart, err := toChart(currentState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
-	desiredChart, err := key.ToChart(desiredState)
+	desiredChart, err := toChart(desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/app/v1/resource/chart/desired_test.go
+++ b/service/controller/app/v1/resource/chart/desired_test.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
-	"github.com/giantswarm/app-operator/service/controller/app/v1/key"
 )
 
 func Test_Resource_GetDesiredState(t *testing.T) {
@@ -30,7 +29,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Name:      "my-cool-prometheus",
 					Namespace: "default",
 					Labels: map[string]string{
-						"app":                                "prometheus",
+						"app": "prometheus",
 						"app-operator.giantswarm.io/version": "1.0.0",
 						"giantswarm.io/managed-by":           "cluster-operator",
 					},
@@ -81,7 +80,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Name:      "my-cool-prometheus",
 					Namespace: "giantswarm",
 					Labels: map[string]string{
-						"app":                                  "prometheus",
+						"app": "prometheus",
 						"chart-operator.giantswarm.io/version": "1.0.0",
 						"giantswarm.io/managed-by":             "app-operator",
 					},
@@ -106,7 +105,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Name:      "my-cool-prometheus",
 					Namespace: "default",
 					Labels: map[string]string{
-						"app":                                "prometheus",
+						"app": "prometheus",
 						"app-operator.giantswarm.io/version": "1.0.0",
 						"giantswarm.io/managed-by":           "cluster-operator",
 					},
@@ -186,7 +185,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 			}
 
 			if err == nil && tc.errorMatcher == nil {
-				chart, err := key.ToChart(result)
+				chart, err := toChart(result)
 				if err != nil {
 					t.Fatalf("error == %#v, want nil", err)
 				}
@@ -423,14 +422,14 @@ func Test_processLabels(t *testing.T) {
 			name:        "case 1: extra labels still present",
 			projectName: "app-operator",
 			inputLabels: map[string]string{
-				"app":                                "prometheus",
+				"app": "prometheus",
 				"app-operator.giantswarm.io/version": "1.0.0",
 				"giantswarm.io/cluster":              "5xchu",
 				"giantswarm.io/managed-by":           "cluster-operator",
 				"giantswarm.io/organization":         "giantswarm",
 			},
 			expectedLabels: map[string]string{
-				"app":                                  "prometheus",
+				"app": "prometheus",
 				"chart-operator.giantswarm.io/version": "1.0.0",
 				"giantswarm.io/cluster":                "5xchu",
 				"giantswarm.io/managed-by":             "app-operator",

--- a/service/controller/app/v1/resource/chart/desired_test.go
+++ b/service/controller/app/v1/resource/chart/desired_test.go
@@ -29,7 +29,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Name:      "my-cool-prometheus",
 					Namespace: "default",
 					Labels: map[string]string{
-						"app": "prometheus",
+						"app":                                "prometheus",
 						"app-operator.giantswarm.io/version": "1.0.0",
 						"giantswarm.io/managed-by":           "cluster-operator",
 					},
@@ -80,7 +80,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Name:      "my-cool-prometheus",
 					Namespace: "giantswarm",
 					Labels: map[string]string{
-						"app": "prometheus",
+						"app":                                  "prometheus",
 						"chart-operator.giantswarm.io/version": "1.0.0",
 						"giantswarm.io/managed-by":             "app-operator",
 					},
@@ -105,7 +105,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Name:      "my-cool-prometheus",
 					Namespace: "default",
 					Labels: map[string]string{
-						"app": "prometheus",
+						"app":                                "prometheus",
 						"app-operator.giantswarm.io/version": "1.0.0",
 						"giantswarm.io/managed-by":           "cluster-operator",
 					},
@@ -422,14 +422,14 @@ func Test_processLabels(t *testing.T) {
 			name:        "case 1: extra labels still present",
 			projectName: "app-operator",
 			inputLabels: map[string]string{
-				"app": "prometheus",
+				"app":                                "prometheus",
 				"app-operator.giantswarm.io/version": "1.0.0",
 				"giantswarm.io/cluster":              "5xchu",
 				"giantswarm.io/managed-by":           "cluster-operator",
 				"giantswarm.io/organization":         "giantswarm",
 			},
 			expectedLabels: map[string]string{
-				"app": "prometheus",
+				"app":                                  "prometheus",
 				"chart-operator.giantswarm.io/version": "1.0.0",
 				"giantswarm.io/cluster":                "5xchu",
 				"giantswarm.io/managed-by":             "app-operator",

--- a/service/controller/app/v1/resource/chart/resource.go
+++ b/service/controller/app/v1/resource/chart/resource.go
@@ -98,3 +98,17 @@ func equals(a, b v1alpha1.Chart) bool {
 func isEmpty(c v1alpha1.Chart) bool {
 	return equals(c, v1alpha1.Chart{})
 }
+
+// toChart converts the input into a Chart.
+func toChart(v interface{}) (v1alpha1.Chart, error) {
+	if v == nil {
+		return v1alpha1.Chart{}, nil
+	}
+
+	chart, ok := v.(*v1alpha1.Chart)
+	if !ok {
+		return v1alpha1.Chart{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.Chart{}, v)
+	}
+
+	return *chart, nil
+}

--- a/service/controller/app/v1/resource/chart/update.go
+++ b/service/controller/app/v1/resource/chart/update.go
@@ -18,7 +18,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	chart, err := key.ToChart(updateChange)
+	chart, err := toChart(updateChange)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -61,12 +61,12 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentChart, desire
 }
 
 func (r *Resource) newUpdateChange(ctx context.Context, currentResource, desiredResource interface{}) (interface{}, error) {
-	currentChart, err := key.ToChart(currentResource)
+	currentChart, err := toChart(currentResource)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	desiredChart, err := key.ToChart(desiredResource)
+	desiredChart, err := toChart(desiredResource)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}


### PR DESCRIPTION
I'd like to align the chart resource with the configmap and secret resources. Currently `toChart` is in the `key` package but it doesn't need to be.