### PR TITLE
Use pointers for chart CRs

### DIFF
--- a/service/controller/app/v1/resource/chart/create.go
+++ b/service/controller/app/v1/resource/chart/create.go
@@ -31,7 +31,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			return microerror.Mask(err)
 		}
 
-		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.GetNamespace()).Create(&chart)
+		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.GetNamespace()).Create(chart)
 		if apierrors.IsAlreadyExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created Chart CR %#q in namespace %#q", chart.Name, chart.Namespace))
 		} else if err != nil {
@@ -60,7 +60,7 @@ func (r *Resource) newCreateChange(ctx context.Context, currentResource, desired
 
 	if isEmpty(currentChart) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %#q chart needs to be created", desiredChart.Name))
-		createChart = &desiredChart
+		createChart = desiredChart
 	} else {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %#q chart does not need to be created", desiredChart.Name))
 	}

--- a/service/controller/app/v1/resource/chart/delete.go
+++ b/service/controller/app/v1/resource/chart/delete.go
@@ -73,7 +73,7 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 	if isModified {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %#q chart needs to be deleted", desiredChart.Name))
 
-		return &desiredChart, nil
+		return desiredChart, nil
 	} else {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %#q chart does not need to be deleted", desiredChart.Name))
 	}

--- a/service/controller/app/v1/resource/chart/delete_test.go
+++ b/service/controller/app/v1/resource/chart/delete_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
 	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -19,7 +20,13 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 		expectedChart   *v1alpha1.Chart
 	}{
 		{
-			name: "case 0: chart should be deleted",
+			name:            "case 0: empty current and desired, expected empty",
+			currentResource: &v1alpha1.Chart{},
+			desiredResource: &v1alpha1.Chart{},
+			expectedChart:   nil,
+		},
+		{
+			name: "case 1: chart should be deleted",
 			currentResource: &v1alpha1.Chart{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Chart",
@@ -73,7 +80,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 			},
 		},
 		{
-			name: "case 1: chart should not deleted",
+			name: "case 2: chart should not deleted",
 			currentResource: &v1alpha1.Chart{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Chart",
@@ -132,13 +139,14 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 				t.Fatalf("error = %v", err)
 				return
 			}
-			if tt.expectedChart == nil && got != nil {
-				t.Fatal("expected", nil, "got", got)
+
+			chart, err := toChart(got)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
 			}
-			if got != nil {
-				if !reflect.DeepEqual(got, tt.expectedChart) {
-					t.Fatalf("got %v, want %v", got, tt.expectedChart)
-				}
+
+			if !reflect.DeepEqual(chart, tt.expectedChart) {
+				t.Fatalf("want matching chart \n %s", cmp.Diff(got, tt.expectedChart))
 			}
 		})
 	}

--- a/service/controller/app/v1/resource/chart/resource.go
+++ b/service/controller/app/v1/resource/chart/resource.go
@@ -78,7 +78,7 @@ func (r *Resource) Name() string {
 }
 
 // equals asseses the equality of ReleaseStates with regards to distinguishing fields.
-func equals(a, b v1alpha1.Chart) bool {
+func equals(a, b *v1alpha1.Chart) bool {
 	if a.Name != b.Name {
 		return false
 	}
@@ -95,20 +95,24 @@ func equals(a, b v1alpha1.Chart) bool {
 }
 
 // isEmpty checks if a ReleaseState is empty.
-func isEmpty(c v1alpha1.Chart) bool {
-	return equals(c, v1alpha1.Chart{})
+func isEmpty(c *v1alpha1.Chart) bool {
+	if c == nil {
+		return true
+	}
+
+	return equals(c, &v1alpha1.Chart{})
 }
 
 // toChart converts the input into a Chart.
-func toChart(v interface{}) (v1alpha1.Chart, error) {
+func toChart(v interface{}) (*v1alpha1.Chart, error) {
 	if v == nil {
-		return v1alpha1.Chart{}, nil
+		return nil, nil
 	}
 
 	chart, ok := v.(*v1alpha1.Chart)
 	if !ok {
-		return v1alpha1.Chart{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.Chart{}, v)
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.Chart{}, v)
 	}
 
-	return *chart, nil
+	return chart, nil
 }

--- a/service/controller/app/v1/resource/chart/update.go
+++ b/service/controller/app/v1/resource/chart/update.go
@@ -31,7 +31,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			return microerror.Mask(err)
 		}
 
-		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.GetNamespace()).Update(&chart)
+		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(cr.GetNamespace()).Update(chart)
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
Aligns the chart resource with the configmap and secret resources. Using a pointer for the chart CR simplifies because we can return nil in case of errors.