### PR TITLE
Do not copy annotation from app

### DIFF
--- a/service/controller/app/v1/resource/chart/delete.go
+++ b/service/controller/app/v1/resource/chart/delete.go
@@ -69,8 +69,8 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %#q chart has to be deleted", desiredChart.Name))
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("currentchart : %#q ", currentChart))
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("desiredchart : %#q ", desiredChart))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("currentchart : %#v ", currentChart))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("desiredchart : %#v ", desiredChart))
 
 	isModified := !isEmpty(currentChart) && equals(currentChart, desiredChart)
 	if isModified {

--- a/service/controller/app/v1/resource/chart/delete.go
+++ b/service/controller/app/v1/resource/chart/delete.go
@@ -69,8 +69,8 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %#q chart has to be deleted", desiredChart.Name))
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("currentchart : %#v ", currentChart))
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("desiredchart : %#v ", desiredChart))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("currentchart : %#q ", currentChart))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("desiredchart : %#q ", desiredChart))
 
 	isModified := !isEmpty(currentChart) && equals(currentChart, desiredChart)
 	if isModified {

--- a/service/controller/app/v1/resource/chart/delete.go
+++ b/service/controller/app/v1/resource/chart/delete.go
@@ -69,9 +69,6 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %#q chart has to be deleted", desiredChart.Name))
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("currentchart : %#q ", currentChart))
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("desiredchart : %#q ", desiredChart))
-
 	isModified := !isEmpty(currentChart) && equals(currentChart, desiredChart)
 	if isModified {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %#q chart needs to be deleted", desiredChart.Name))

--- a/service/controller/app/v1/resource/chart/delete.go
+++ b/service/controller/app/v1/resource/chart/delete.go
@@ -69,6 +69,9 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %#q chart has to be deleted", desiredChart.Name))
 
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("currentchart : %#q ", currentChart))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("desiredchart : %#q ", desiredChart))
+
 	isModified := !isEmpty(currentChart) && equals(currentChart, desiredChart)
 	if isModified {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %#q chart needs to be deleted", desiredChart.Name))

--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -39,10 +39,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			APIVersion: chartAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        cr.GetName(),
-			Namespace:   r.chartNamespace,
-			Labels:      processLabels(r.projectName, cr.GetLabels()),
-			Annotations: cr.GetAnnotations(),
+			Name:      cr.GetName(),
+			Namespace: r.chartNamespace,
+			Labels:    processLabels(r.projectName, cr.GetLabels()),
 		},
 		Spec: v1alpha1.ChartSpec{
 			Config:     config,

--- a/service/controller/app/v1/resource/chart/resource.go
+++ b/service/controller/app/v1/resource/chart/resource.go
@@ -85,9 +85,6 @@ func equals(a, b *v1alpha1.Chart) bool {
 	if !reflect.DeepEqual(a.Labels, b.Labels) {
 		return false
 	}
-	if !reflect.DeepEqual(a.Annotations, b.Annotations) {
-		return false
-	}
 	return true
 }
 


### PR DESCRIPTION
We are copying `annotation` in `app` CR into `chart` CR. 
We only need to copy `label`, not `annotation`.