### PR TITLE
Return empty type when input is nil

### DIFF
--- a/service/controller/app/v1/resource/chart/delete_test.go
+++ b/service/controller/app/v1/resource/chart/delete_test.go
@@ -23,7 +23,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 			name:            "case 0: empty current and desired, expected empty",
 			currentResource: &v1alpha1.Chart{},
 			desiredResource: &v1alpha1.Chart{},
-			expectedChart:   nil,
+			expectedChart:   &v1alpha1.Chart{},
 		},
 		{
 			name: "case 1: chart should be deleted",
@@ -83,7 +83,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 					TarballURL: "https://giantswarm.github.com/app-catalog/kubernetes-prometheus-1.0.0.tgz",
 				},
 			},
-			expectedChart: nil,
+			expectedChart: &v1alpha1.Chart{},
 		},
 	}
 

--- a/service/controller/app/v1/resource/chart/resource.go
+++ b/service/controller/app/v1/resource/chart/resource.go
@@ -100,7 +100,7 @@ func isEmpty(c *v1alpha1.Chart) bool {
 // toChart converts the input into a Chart.
 func toChart(v interface{}) (*v1alpha1.Chart, error) {
 	if v == nil {
-		return nil, nil
+		return &v1alpha1.Chart{}, nil
 	}
 
 	chart, ok := v.(*v1alpha1.Chart)

--- a/service/controller/app/v1/resource/configmap/current_test.go
+++ b/service/controller/app/v1/resource/configmap/current_test.go
@@ -83,7 +83,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			expectedConfigMap: nil,
+			expectedConfigMap: &corev1.ConfigMap{},
 		},
 		{
 			name: "case 2: namespace does not match",
@@ -107,7 +107,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			expectedConfigMap: nil,
+			expectedConfigMap: &corev1.ConfigMap{},
 		},
 		{
 			name: "case 3: no configmaps",
@@ -121,7 +121,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 					},
 				},
 			},
-			expectedConfigMap: nil,
+			expectedConfigMap: &corev1.ConfigMap{},
 		},
 	}
 

--- a/service/controller/app/v1/resource/configmap/delete_test.go
+++ b/service/controller/app/v1/resource/configmap/delete_test.go
@@ -26,7 +26,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 			name:              "case 0: empty current and desired, expected empty",
 			currentState:      &corev1.ConfigMap{},
 			desiredState:      &corev1.ConfigMap{},
-			expectedConfigMap: nil,
+			expectedConfigMap: &corev1.ConfigMap{},
 		},
 		{
 			name: "case 1: non empty current and desired, expected desired",
@@ -79,7 +79,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			expectedConfigMap: nil,
+			expectedConfigMap: &corev1.ConfigMap{},
 		},
 	}
 

--- a/service/controller/app/v1/resource/configmap/resource.go
+++ b/service/controller/app/v1/resource/configmap/resource.go
@@ -105,7 +105,7 @@ func isEmpty(c *corev1.ConfigMap) bool {
 // toConfigMap converts the input into a ConfigMap.
 func toConfigMap(v interface{}) (*corev1.ConfigMap, error) {
 	if v == nil {
-		return nil, nil
+		return &corev1.ConfigMap{}, nil
 	}
 
 	configMap, ok := v.(*corev1.ConfigMap)

--- a/service/controller/app/v1/resource/secret/current_test.go
+++ b/service/controller/app/v1/resource/secret/current_test.go
@@ -83,7 +83,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			expectedSecret: nil,
+			expectedSecret: &corev1.Secret{},
 		},
 		{
 			name: "case 2: namespace does not match",
@@ -107,7 +107,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			expectedSecret: nil,
+			expectedSecret: &corev1.Secret{},
 		},
 		{
 			name: "case 3: no secrets",
@@ -121,7 +121,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 					},
 				},
 			},
-			expectedSecret: nil,
+			expectedSecret: &corev1.Secret{},
 		},
 	}
 

--- a/service/controller/app/v1/resource/secret/delete_test.go
+++ b/service/controller/app/v1/resource/secret/delete_test.go
@@ -26,7 +26,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 			name:           "case 0: empty current and desired, expected empty",
 			currentState:   &corev1.Secret{},
 			desiredState:   &corev1.Secret{},
-			expectedSecret: nil,
+			expectedSecret: &corev1.Secret{},
 		},
 		{
 			name: "case 1: non empty current and desired, expected desired",
@@ -79,7 +79,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			expectedSecret: nil,
+			expectedSecret: &corev1.Secret{},
 		},
 	}
 

--- a/service/controller/app/v1/resource/secret/resource.go
+++ b/service/controller/app/v1/resource/secret/resource.go
@@ -105,7 +105,7 @@ func isEmpty(s *corev1.Secret) bool {
 // toSecret converts the input into a Secret.
 func toSecret(v interface{}) (*corev1.Secret, error) {
 	if v == nil {
-		return nil, nil
+		return &corev1.Secret{}, nil
 	}
 
 	secret, ok := v.(*corev1.Secret)


### PR DESCRIPTION
Fix crash found in testing with update handling.

Current state returns nil so `equals` fails. Fix is in `toConfigMap` return an empty type for comparison. All 3 resources have the same problem.

```
D 04/26 12:58:21 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/apps/test-app configmapv1.NewUpdatePatch finding out if the configmap has to be updated | app-operator/service/controller/app/v1/resource/configmap/update.go:68 | controller=app-operator | event=update | loop=2 | version=12859
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1d8eb33]

goroutine 12 [running]:
github.com/giantswarm/app-operator/service/controller/app/v1/resource/configmap.equals(0xc0003b4b40, 0x0, 0xc0004dbe90)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/configmap/resource.go:77 +0x33
github.com/giantswarm/app-operator/service/controller/app/v1/resource/configmap.(*Resource).newUpdateChange(0xc000354c80, 0x220d7a0, 0xc0004dbe90, 0x204b880, 0xc0003b4b40, 0x0, 0x0, 0x204b880, 0xc0003b5200, 0x0, ...)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/configmap/update.go:71 +0x4cc
github.com/giantswarm/app-operator/service/controller/app/v1/resource/configmap.(*Resource).NewUpdatePatch(0xc000354c80, 0x220d7a0, 0xc0004dbe90, 0x2035560, 0xc0001e4f00, 0x204b880, 0xc0003b4b40, 0x0, 0x0, 0x100e318, ...)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/configmap/update.go:45 +0x114
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource.(*crudResourceWrapperOps).NewUpdatePatch.func1(0xc0001f1e40, 0xc0006804e0)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:113 +0x91
github.com/giantswarm/app-operator/vendor/github.com/cenkalti/backoff.RetryNotify(0xc00061e540, 0x7219a80, 0xc0001f1e40, 0xc0006804c0, 0x0, 0x0)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/cenkalti/backoff/retry.go:37 +0xbb
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource.(*crudResourceWrapperOps).NewUpdatePatch(0xc0003b7b00, 0x220d7a0, 0xc0004dbe90, 0x2035560, 0xc0001e4f00, 0x204b880, 0xc0003b4b40, 0x0, 0x0, 0x102cad2, ...)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:125 +0x1e7
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource.(*crudResourceWrapperOps).NewUpdatePatch(0xc0001f1fc0, 0x220d7a0, 0xc0004dbe90, 0x2035560, 0xc0001e4f00, 0x204b880, 0xc0003b4b40, 0x0, 0x0, 0x0, ...)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource/crud_resource_ops_wrapper.go:85 +0x213
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller.(*CRUDResource).EnsureCreated(0xc0001f1e00, 0x220d7a0, 0xc0004dbe90, 0x2035560, 0xc0001e4f00, 0x0, 0x0)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/crud_resource.go:107 +0x33e
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource.(*crudResourceWrapper).EnsureCreated(0xc0003b7b60, 0x220d7a0, 0xc0004dbe90, 0x2035560, 0xc0001e4f00, 0x220d7a0, 0xc0004dbe90)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_wrapper.go:79 +0x60
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource.(*crudResourceWrapper).EnsureCreated(0xc0003a79d0, 0x220d7a0, 0xc0004dbe90, 0x2035560, 0xc0001e4f00, 0xb, 0x220d7a0)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/metricsresource/crud_resource_wrapper.go:60 +0x5f
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller.ProcessUpdate(0x220d7a0, 0xc0004dbe90, 0x2035560, 0xc0001e4f00, 0xc00038afc0, 0x4, 0x4, 0x0, 0x0)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:528 +0x1a9
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).updateFunc(0xc0000f0a00, 0x220d7a0, 0xc0004dbdd0, 0x2035560, 0xc0001e4f00)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:367 +0xa89
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).ProcessEvents(0xc0000f0a00, 0x220d7a0, 0xc0001ade00, 0xc000448060, 0xc0004480c0, 0xc000448120, 0x0, 0x0)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:294 +0xd15
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).bootWithError(0xc0000f0a00, 0x220d7a0, 0xc00017a090, 0x1d333bc, 0xc0000420d0)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:425 +0x45f
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).Boot.func1.1(0xc000402040, 0xc000402060)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:141 +0x3c
github.com/giantswarm/app-operator/vendor/github.com/cenkalti/backoff.RetryNotify(0xc000402020, 0x7219a80, 0xc000402040, 0xc00017a180, 0x0, 0x0)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/cenkalti/backoff/retry.go:37 +0xbb
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).Boot.func1()
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:151 +0x13e
sync.(*Once).Do(0xc0000f0a58, 0xc0001bd798)
	/Users/ross/.gvm/gos/go1.11.2/src/sync/once.go:44 +0xb3
github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller.(*Controller).Boot(0xc0000f0a00, 0x220d720, 0xc0000c2008)
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:139 +0xbc
created by github.com/giantswarm/app-operator/service.(*Service).Boot.func1
	/Users/ross/.gvm/pkgsets/go1.11.2/global/src/github.com/giantswarm/app-operator/service/service.go:164 +0xac
exit status 2
```

