### PR TITLE
Use key package for release names

### DIFF
--- a/integration/key/release_name.go
+++ b/integration/key/release_name.go
@@ -5,3 +5,15 @@ package key
 func AppOperatorReleaseName() string {
 	return "app-operator"
 }
+
+func CustomResourceReleaseName() string {
+	return "apiextensions-app-e2e-chart"
+}
+
+func TestAppReleaseName() string {
+	return "kubernetes-test-app-chart"
+}
+
+func TestAppCatalogReleaseName() string {
+	return "test-app-catalog"
+}

--- a/integration/test/app/basic/simple_test.go
+++ b/integration/test/app/basic/simple_test.go
@@ -3,13 +3,15 @@
 package basic
 
 import (
+	"context"
 	"fmt"
-	"golang.org/x/net/context"
 	"testing"
 
 	"github.com/giantswarm/e2e-harness/pkg/release"
 	"github.com/giantswarm/e2etemplates/pkg/chartvalues"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/app-operator/integration/key"
 )
 
 const (

--- a/integration/test/app/basic/simple_test.go
+++ b/integration/test/app/basic/simple_test.go
@@ -15,11 +15,9 @@ import (
 )
 
 const (
-	namespace                 = "giantswarm"
-	customResourceReleaseName = "apiextensions-app-e2e-chart"
-	chartOperatorVersion      = "chart-operator.giantswarm.io/version"
-	testAppReleaseName        = "kubernetes-test-app-chart"
-	testAppCatalogReleaseName = "test-app-catalog"
+	namespace            = "giantswarm"
+	chartOperatorVersion = "chart-operator.giantswarm.io/version"
+	testAppCatalogName   = "test-app-catalog"
 )
 
 // TestAppLifecycle tests a chart CR can be created, updated and deleted
@@ -41,14 +39,14 @@ func TestAppLifecycle(t *testing.T) {
 
 	sampleChart := chartvalues.APIExtensionsAppE2EConfig{
 		App: chartvalues.APIExtensionsAppE2EConfigApp{
-			Name:      testAppReleaseName,
+			Name:      key.TestAppReleaseName(),
 			Namespace: namespace,
-			Catalog:   testAppCatalogReleaseName,
+			Catalog:   testAppCatalogName,
 			Version:   "0.6.7",
 		},
 		AppCatalog: chartvalues.APIExtensionsAppE2EConfigAppCatalog{
-			Name:  testAppCatalogReleaseName,
-			Title: testAppCatalogReleaseName,
+			Name:  testAppCatalogName,
+			Title: testAppCatalogName,
 			Storage: chartvalues.APIExtensionsAppE2EConfigAppCatalogStorage{
 				Type: "helm",
 				URL:  "https://giantswarm.github.com/sample-catalog",
@@ -61,43 +59,43 @@ func TestAppLifecycle(t *testing.T) {
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chart value for release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chart value for release %#q", key.CustomResourceReleaseName()))
 
 		chartValues, err = chartvalues.NewAPIExtensionsAppE2E(sampleChart)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart value for release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart value for release %#q", key.CustomResourceReleaseName()))
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installing release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installing release %#q", key.CustomResourceReleaseName()))
 
-		chartInfo := release.NewStableChartInfo(customResourceReleaseName)
-		err = config.Release.Install(ctx, customResourceReleaseName, chartInfo, chartValues)
+		chartInfo := release.NewStableChartInfo(key.CustomResourceReleaseName())
+		err = config.Release.Install(ctx, key.CustomResourceReleaseName(), chartInfo, chartValues)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installed release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installed release %#q", key.CustomResourceReleaseName()))
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for release %#q deployed", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for release %#q deployed", key.CustomResourceReleaseName()))
 
-		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", namespace, customResourceReleaseName), "DEPLOYED")
+		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", namespace, key.CustomResourceReleaseName()), "DEPLOYED")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for release %#q deployed", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for release %#q deployed", key.CustomResourceReleaseName()))
 	}
 
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "waiting for chart CR created")
 
-		err = config.Release.WaitForStatus(ctx, testAppReleaseName, "DEPLOYED")
+		err = config.Release.WaitForStatus(ctx, key.TestAppReleaseName(), "DEPLOYED")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -109,7 +107,7 @@ func TestAppLifecycle(t *testing.T) {
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "checking tarball URL in chart spec")
 
 		tarballURL := "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.6.7.tgz"
-		chart, err := config.Host.G8sClient().ApplicationV1alpha1().Charts(namespace).Get(testAppReleaseName, metav1.GetOptions{})
+		chart, err := config.Host.G8sClient().ApplicationV1alpha1().Charts(namespace).Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -124,7 +122,7 @@ func TestAppLifecycle(t *testing.T) {
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart value for release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart value for release %#q", key.CustomResourceReleaseName()))
 
 		sampleChart.App.Version = "0.6.8"
 		chartValues, err = chartvalues.NewAPIExtensionsAppE2E(sampleChart)
@@ -132,41 +130,41 @@ func TestAppLifecycle(t *testing.T) {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart value for release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart value for release %#q", key.CustomResourceReleaseName()))
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating release %#q", key.CustomResourceReleaseName()))
 
-		chartInfo := release.NewStableChartInfo(customResourceReleaseName)
-		err = config.Release.Update(ctx, customResourceReleaseName, chartInfo, chartValues)
+		chartInfo := release.NewStableChartInfo(key.CustomResourceReleaseName())
+		err = config.Release.Update(ctx, key.CustomResourceReleaseName(), chartInfo, chartValues)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated release %#q", key.CustomResourceReleaseName()))
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for release %#q deployed", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for release %#q deployed", key.CustomResourceReleaseName()))
 
-		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", namespace, customResourceReleaseName), "DEPLOYED")
+		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", namespace, key.CustomResourceReleaseName()), "DEPLOYED")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for release %#q deployed", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for release %#q deployed", key.CustomResourceReleaseName()))
 	}
 
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "checking tarball URL in chart spec")
 
-		err = config.Release.WaitForChartInfo(ctx, testAppReleaseName, "0.6.8")
+		err = config.Release.WaitForChartInfo(ctx, key.TestAppReleaseName(), "0.6.8")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		chart, err := config.Host.G8sClient().ApplicationV1alpha1().Charts(namespace).Get(testAppReleaseName, metav1.GetOptions{})
+		chart, err := config.Host.G8sClient().ApplicationV1alpha1().Charts(namespace).Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -180,31 +178,31 @@ func TestAppLifecycle(t *testing.T) {
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %#q", key.CustomResourceReleaseName()))
 
-		err := config.Release.Delete(ctx, customResourceReleaseName)
+		err := config.Release.Delete(ctx, key.CustomResourceReleaseName())
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %#q", key.CustomResourceReleaseName()))
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for release %#q deleted", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for release %#q deleted", key.CustomResourceReleaseName()))
 
-		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", namespace, customResourceReleaseName), "DELETED")
+		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", namespace, key.CustomResourceReleaseName()), "DELETED")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for release %#q deleted", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for release %#q deleted", key.CustomResourceReleaseName()))
 	}
 
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "checking chart CR had been deleted")
 
-		err = config.Release.WaitForStatus(ctx, testAppReleaseName, "DELETED")
+		err = config.Release.WaitForStatus(ctx, key.TestAppReleaseName(), "DELETED")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}

--- a/integration/test/app/kubeconfig/kubeconfig_test.go
+++ b/integration/test/app/kubeconfig/kubeconfig_test.go
@@ -17,12 +17,10 @@ import (
 )
 
 const (
-	namespace                 = "giantswarm"
-	customResourceReleaseName = "apiextensions-app-e2e-chart"
-	chartOperatorVersion      = "chart-operator.giantswarm.io/version"
-	targetNamespace           = "test"
-	testAppReleaseName        = "kubernetes-test-app-chart"
-	testAppCatalogReleaseName = "test-app-catalog"
+	namespace            = "giantswarm"
+	chartOperatorVersion = "chart-operator.giantswarm.io/version"
+	targetNamespace      = "test"
+	testAppCatalogName   = "test-app-catalog"
 )
 
 // TestAppLifecycleUsingKubeconfig perform same tests as TestAppLifeCycle except it using kubeConfig spec
@@ -40,14 +38,14 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 					Namespace: namespace,
 				},
 			},
-			Name:      testAppReleaseName,
+			Name:      key.TestAppReleaseName(),
 			Namespace: namespace,
-			Catalog:   testAppCatalogReleaseName,
+			Catalog:   testAppCatalogName,
 			Version:   "0.6.7",
 		},
 		AppCatalog: chartvalues.APIExtensionsAppE2EConfigAppCatalog{
-			Name:  testAppCatalogReleaseName,
-			Title: testAppCatalogReleaseName,
+			Name:  testAppCatalogName,
+			Title: testAppCatalogName,
 			Storage: chartvalues.APIExtensionsAppE2EConfigAppCatalogStorage{
 				Type: "helm",
 				URL:  "https://giantswarm.github.com/sample-catalog",
@@ -85,43 +83,43 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chart value for release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating chart value for release %#q", key.CustomResourceReleaseName()))
 
 		chartValues, err = chartvalues.NewAPIExtensionsAppE2E(sampleChart)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart value for release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created chart value for release %#q", key.CustomResourceReleaseName()))
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installing release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installing release %#q", key.CustomResourceReleaseName()))
 
-		chartInfo := release.NewStableChartInfo(customResourceReleaseName)
-		err = config.Release.Install(ctx, customResourceReleaseName, chartInfo, chartValues)
+		chartInfo := release.NewStableChartInfo(key.CustomResourceReleaseName())
+		err = config.Release.Install(ctx, key.CustomResourceReleaseName(), chartInfo, chartValues)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installed release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("installed release %#q", key.CustomResourceReleaseName()))
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for release %#q deployed", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for release %#q deployed", key.CustomResourceReleaseName()))
 
-		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", namespace, customResourceReleaseName), "DEPLOYED")
+		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", namespace, key.CustomResourceReleaseName()), "DEPLOYED")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for release %#q deployed", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for release %#q deployed", key.CustomResourceReleaseName()))
 	}
 
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "waiting for chart CR created")
 
-		err = config.Release.WaitForStatus(ctx, testAppReleaseName, "DEPLOYED")
+		err = config.Release.WaitForStatus(ctx, key.TestAppReleaseName(), "DEPLOYED")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -133,7 +131,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "checking tarball URL in chart spec")
 
 		tarballURL := "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.6.7.tgz"
-		chart, err := config.Host.G8sClient().ApplicationV1alpha1().Charts(namespace).Get(testAppReleaseName, metav1.GetOptions{})
+		chart, err := config.Host.G8sClient().ApplicationV1alpha1().Charts(namespace).Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -148,7 +146,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart value for release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart value for release %#q", key.CustomResourceReleaseName()))
 
 		sampleChart.App.Version = "0.6.8"
 		chartValues, err = chartvalues.NewAPIExtensionsAppE2E(sampleChart)
@@ -156,41 +154,41 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart value for release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated chart value for release %#q", key.CustomResourceReleaseName()))
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating release %#q", key.CustomResourceReleaseName()))
 
-		chartInfo := release.NewStableChartInfo(customResourceReleaseName)
-		err = config.Release.Update(ctx, customResourceReleaseName, chartInfo, chartValues)
+		chartInfo := release.NewStableChartInfo(key.CustomResourceReleaseName())
+		err = config.Release.Update(ctx, key.CustomResourceReleaseName(), chartInfo, chartValues)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated release %#q", key.CustomResourceReleaseName()))
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for release %#q deployed", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for release %#q deployed", key.CustomResourceReleaseName()))
 
-		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", namespace, customResourceReleaseName), "DEPLOYED")
+		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", namespace, key.CustomResourceReleaseName()), "DEPLOYED")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for release %#q deployed", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for release %#q deployed", key.CustomResourceReleaseName()))
 	}
 
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "checking tarball URL in chart spec")
 
-		err = config.Release.WaitForChartInfo(ctx, testAppReleaseName, "0.6.8")
+		err = config.Release.WaitForChartInfo(ctx, key.TestAppReleaseName(), "0.6.8")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		chart, err := config.Host.G8sClient().ApplicationV1alpha1().Charts(namespace).Get(testAppReleaseName, metav1.GetOptions{})
+		chart, err := config.Host.G8sClient().ApplicationV1alpha1().Charts(namespace).Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -204,31 +202,31 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %#q", key.CustomResourceReleaseName()))
 
-		err := config.Release.Delete(ctx, customResourceReleaseName)
+		err := config.Release.Delete(ctx, key.CustomResourceReleaseName())
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %#q", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted release %#q", key.CustomResourceReleaseName()))
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for release %#q deleted", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for release %#q deleted", key.CustomResourceReleaseName()))
 
-		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", namespace, customResourceReleaseName), "DELETED")
+		err = config.Release.WaitForStatus(ctx, fmt.Sprintf("%s-%s", namespace, key.CustomResourceReleaseName()), "DELETED")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for release %#q deleted", customResourceReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for release %#q deleted", key.CustomResourceReleaseName()))
 	}
 
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "checking chart CR had been deleted")
 
-		err = config.Release.WaitForStatus(ctx, testAppReleaseName, "DELETED")
+		err = config.Release.WaitForStatus(ctx, key.TestAppReleaseName(), "DELETED")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}

--- a/integration/test/app/kubeconfig/kubeconfig_test.go
+++ b/integration/test/app/kubeconfig/kubeconfig_test.go
@@ -3,8 +3,8 @@
 package kubeconfig
 
 import (
+	"context"
 	"fmt"
-	"golang.org/x/net/context"
 	"testing"
 
 	"github.com/giantswarm/e2e-harness/pkg/release"
@@ -12,6 +12,8 @@ import (
 	"github.com/giantswarm/kubeconfig"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/app-operator/integration/key"
 )
 
 const (


### PR DESCRIPTION
We need to add e2e test coverage for the values support. This is some prep to use the `key` package for more Helm release names.