### PR TITLE
Fix bug when configmap name or secret name is empty

### DIFF
--- a/service/controller/app/v1/resource/configmap/desired.go
+++ b/service/controller/app/v1/resource/configmap/desired.go
@@ -79,8 +79,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 
 func (r *Resource) getConfigMap(ctx context.Context, configMapName, configMapNamespace string) (map[string]string, error) {
 	if configMapName == "" {
-		// Return early.
-		return map[string]string{}, nil
+		// Return early as no configmap has been specified.
+		return nil, nil
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("looking for configmap %#q in namespace %#q", configMapName, configMapNamespace))

--- a/service/controller/app/v1/resource/configmap/desired.go
+++ b/service/controller/app/v1/resource/configmap/desired.go
@@ -77,7 +77,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	return configMap, nil
 }
 
-func (r *Resource) getConfigMap(ctx context.Context, configMapName, configMapNamespace string) (*corev1.ConfigMap, error) {
+func (r *Resource) getConfigMap(ctx context.Context, configMapName, configMapNamespace string) (map[string]string, error) {
+	if configMapName == "" {
+		// Return early.
+		return map[string]string{}, nil
+	}
+
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("looking for configmap %#q in namespace %#q", configMapName, configMapNamespace))
 
 	configMap, err := r.k8sClient.CoreV1().ConfigMaps(configMapNamespace).Get(configMapName, metav1.GetOptions{})
@@ -89,7 +94,7 @@ func (r *Resource) getConfigMap(ctx context.Context, configMapName, configMapNam
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found configmap %#q in namespace %#q", configMapName, configMapNamespace))
 
-	return configMap, nil
+	return configMap.Data, nil
 }
 
 func (r *Resource) getConfigMapForApp(ctx context.Context, app v1alpha1.App) (map[string]string, error) {
@@ -98,7 +103,7 @@ func (r *Resource) getConfigMapForApp(ctx context.Context, app v1alpha1.App) (ma
 		return nil, microerror.Mask(err)
 	}
 
-	return configMap.Data, nil
+	return configMap, nil
 }
 
 func (r *Resource) getConfigMapForCatalog(ctx context.Context, catalog v1alpha1.AppCatalog) (map[string]string, error) {
@@ -107,5 +112,5 @@ func (r *Resource) getConfigMapForCatalog(ctx context.Context, catalog v1alpha1.
 		return nil, microerror.Mask(err)
 	}
 
-	return configMap.Data, nil
+	return configMap, nil
 }

--- a/service/controller/app/v1/resource/secret/desired.go
+++ b/service/controller/app/v1/resource/secret/desired.go
@@ -77,7 +77,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	return secret, nil
 }
 
-func (r *Resource) getSecret(ctx context.Context, secretName, secretNamespace string) (*corev1.Secret, error) {
+func (r *Resource) getSecret(ctx context.Context, secretName, secretNamespace string) (map[string][]byte, error) {
+	if secretName == "" {
+		//Return early.
+		return map[string][]byte{}, nil
+	}
+
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("looking for secret %#q in namespace %#q", secretName, secretNamespace))
 
 	secret, err := r.k8sClient.CoreV1().Secrets(secretNamespace).Get(secretName, metav1.GetOptions{})
@@ -89,7 +94,7 @@ func (r *Resource) getSecret(ctx context.Context, secretName, secretNamespace st
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found secret %#q in namespace %#q", secretName, secretNamespace))
 
-	return secret, nil
+	return secret.Data, nil
 }
 
 func (r *Resource) getSecretDataForApp(ctx context.Context, app v1alpha1.App) (map[string][]byte, error) {
@@ -102,7 +107,7 @@ func (r *Resource) getSecretDataForApp(ctx context.Context, app v1alpha1.App) (m
 		return nil, microerror.Mask(err)
 	}
 
-	return secret.Data, nil
+	return secret, nil
 }
 
 func (r *Resource) getSecretDataForCatalog(ctx context.Context, catalog v1alpha1.AppCatalog) (map[string][]byte, error) {
@@ -115,5 +120,5 @@ func (r *Resource) getSecretDataForCatalog(ctx context.Context, catalog v1alpha1
 		return nil, microerror.Mask(err)
 	}
 
-	return secret.Data, nil
+	return secret, nil
 }

--- a/service/controller/app/v1/resource/secret/desired.go
+++ b/service/controller/app/v1/resource/secret/desired.go
@@ -79,8 +79,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 
 func (r *Resource) getSecret(ctx context.Context, secretName, secretNamespace string) (map[string][]byte, error) {
 	if secretName == "" {
-		//Return early.
-		return map[string][]byte{}, nil
+		// Return early as no secret has been specified.
+		return nil, nil
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("looking for secret %#q in namespace %#q", secretName, secretNamespace))


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/5919

Fixes a problem @webwurst hit when installing an app in `talos` earlier. This is a bug I introduced with my recent config merging changes. 

Error is `resource name may not be empty` when fetching a configmap or secret. So now we return early if the name is empty.