### PR TITLE
Extract values package with logic for merging configmaps and secrets

### DIFF
--- a/service/controller/app/v1/resource/configmap/resource.go
+++ b/service/controller/app/v1/resource/configmap/resource.go
@@ -115,15 +115,3 @@ func toConfigMap(v interface{}) (*corev1.ConfigMap, error) {
 
 	return configMap, nil
 }
-
-// toByteSliceMap converts from a string map to a byte slice map so the input
-// can be merged.
-func toByteSliceMap(input map[string]string) map[string][]byte {
-	result := map[string][]byte{}
-
-	for k, v := range input {
-		result[k] = []byte(v)
-	}
-
-	return result
-}

--- a/service/controller/app/v1/values/values.go
+++ b/service/controller/app/v1/values/values.go
@@ -1,0 +1,74 @@
+package values
+
+import (
+	"github.com/giantswarm/helmclient"
+	"github.com/giantswarm/microerror"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// MergeConfigMapData merges configmap data into a single block of YAML that
+// is stored in the configmap associated with the relevant chart CR.
+func MergeConfigMapData(destMap, srcMap map[string]string) (map[string]string, error) {
+	result, err := mergeData(toByteSliceMap(destMap), toByteSliceMap(srcMap))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return toStringMap(result), nil
+}
+
+// MergeSecretData merges secret data into a single block of YAML that
+// is stored in the secret associated with the relevant chart CR.
+func MergeSecretData(destMap, srcMap map[string][]byte) (map[string][]byte, error) {
+	result, err := mergeData(destMap, srcMap)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return result, nil
+}
+
+// mergeData contains the shared logic that is common to merging configmap and
+// secret data.
+func mergeData(destMap, srcMap map[string][]byte) (map[string][]byte, error) {
+	mergedData, err := helmclient.MergeValues(destMap, srcMap)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	bytes, err := yaml.Marshal(mergedData)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// Key name is just for display purposes. The only restriction is the
+	// configmap or secret storing data for the chart CR can only have a single
+	// key with YAML values.
+	result := map[string][]byte{
+		"values": bytes,
+	}
+
+	return result, nil
+}
+
+// toByteSliceMap converts from a string map to a byte slice map.
+func toByteSliceMap(input map[string]string) map[string][]byte {
+	result := map[string][]byte{}
+
+	for k, v := range input {
+		result[k] = []byte(v)
+	}
+
+	return result
+}
+
+// toStringMap converts from a byte slice map to a string map.
+func toStringMap(input map[string][]byte) map[string]string {
+	result := map[string]string{}
+
+	for k, v := range input {
+		result[k] = string(v)
+	}
+
+	return result
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5885

The logic for merging configmaps and secrets is the same. The only difference is configmap data uses `map[string]string` and secret uses `map[string][]byte`. This PR extracts the logic to a new `values` package.

This is prep for merging user config. If an app CR has user config we will do a 2nd merge using the values package. As most app CRs won't have user config e.g. we won't use it in CP for VOO.
