### PR TITLE
Change the namespace for cm, secret

### DIFF
--- a/service/controller/app/v1/resource/configmap/create_test.go
+++ b/service/controller/app/v1/resource/configmap/create_test.go
@@ -96,6 +96,7 @@ func Test_Resource_newCreateChange(t *testing.T) {
 		K8sClient: clientgofake.NewSimpleClientset(),
 		Logger:    microloggertest.New(),
 
+		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
 		WatchNamespace: "default",
 	}

--- a/service/controller/app/v1/resource/configmap/current_test.go
+++ b/service/controller/app/v1/resource/configmap/current_test.go
@@ -149,6 +149,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 				K8sClient: k8sClient,
 				Logger:    microloggertest.New(),
 
+				ChartNamespace: "giantswarm",
 				ProjectName:    "app-operator",
 				WatchNamespace: "default",
 			}

--- a/service/controller/app/v1/resource/configmap/delete_test.go
+++ b/service/controller/app/v1/resource/configmap/delete_test.go
@@ -88,6 +88,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 		K8sClient: clientgofake.NewSimpleClientset(),
 		Logger:    microloggertest.New(),
 
+		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
 		WatchNamespace: "default",
 	}

--- a/service/controller/app/v1/resource/configmap/desired.go
+++ b/service/controller/app/v1/resource/configmap/desired.go
@@ -75,7 +75,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		Data: mergedData,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      key.ChartConfigMapName(cr),
-			Namespace: key.Namespace(cr),
+			Namespace: r.chartNamespace,
 			Labels: map[string]string{
 				label.ManagedBy: r.projectName,
 			},

--- a/service/controller/app/v1/resource/configmap/desired_test.go
+++ b/service/controller/app/v1/resource/configmap/desired_test.go
@@ -88,7 +88,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-prometheus-chart-values",
-					Namespace: "monitoring",
+					Namespace: "giantswarm",
 					Labels: map[string]string{
 						label.ManagedBy: "app-operator",
 					},
@@ -381,6 +381,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				K8sClient: clientgofake.NewSimpleClientset(objs...),
 				Logger:    microloggertest.New(),
 
+				ChartNamespace: "giantswarm",
 				ProjectName:    "app-operator",
 				WatchNamespace: "default",
 			}

--- a/service/controller/app/v1/resource/configmap/resource.go
+++ b/service/controller/app/v1/resource/configmap/resource.go
@@ -23,6 +23,7 @@ type Config struct {
 	Logger    micrologger.Logger
 
 	// Settings.
+	ChartNamespace string
 	ProjectName    string
 	WatchNamespace string
 }
@@ -35,6 +36,7 @@ type Resource struct {
 	logger    micrologger.Logger
 
 	// Settings.
+	chartNamespace string
 	projectName    string
 	watchNamespace string
 }
@@ -51,6 +53,9 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
+	if config.ChartNamespace == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ChartNamespace must not be empty", config)
+	}
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
 	}
@@ -60,6 +65,7 @@ func New(config Config) (*Resource, error) {
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
 
+		chartNamespace: config.ChartNamespace,
 		projectName:    config.ProjectName,
 		watchNamespace: config.WatchNamespace,
 	}

--- a/service/controller/app/v1/resource/configmap/update_test.go
+++ b/service/controller/app/v1/resource/configmap/update_test.go
@@ -135,6 +135,7 @@ func Test_Resource_newUpdateChange(t *testing.T) {
 		K8sClient: clientgofake.NewSimpleClientset(),
 		Logger:    microloggertest.New(),
 
+		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
 		WatchNamespace: "default",
 	}

--- a/service/controller/app/v1/resource/secret/create_test.go
+++ b/service/controller/app/v1/resource/secret/create_test.go
@@ -96,6 +96,7 @@ func Test_Resource_newCreateChange(t *testing.T) {
 		K8sClient: clientgofake.NewSimpleClientset(),
 		Logger:    microloggertest.New(),
 
+		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
 		WatchNamespace: "default",
 	}

--- a/service/controller/app/v1/resource/secret/current_test.go
+++ b/service/controller/app/v1/resource/secret/current_test.go
@@ -149,6 +149,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 				K8sClient: k8sClient,
 				Logger:    microloggertest.New(),
 
+				ChartNamespace: "giantswarm",
 				ProjectName:    "app-operator",
 				WatchNamespace: "default",
 			}

--- a/service/controller/app/v1/resource/secret/delete_test.go
+++ b/service/controller/app/v1/resource/secret/delete_test.go
@@ -88,6 +88,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 		K8sClient: clientgofake.NewSimpleClientset(),
 		Logger:    microloggertest.New(),
 
+		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
 		WatchNamespace: "default",
 	}

--- a/service/controller/app/v1/resource/secret/desired.go
+++ b/service/controller/app/v1/resource/secret/desired.go
@@ -75,7 +75,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		Data: mergedData,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      key.ChartSecretName(cr),
-			Namespace: key.Namespace(cr),
+			Namespace: r.chartNamespace,
 			Labels: map[string]string{
 				label.ManagedBy: r.projectName,
 			},

--- a/service/controller/app/v1/resource/secret/desired_test.go
+++ b/service/controller/app/v1/resource/secret/desired_test.go
@@ -88,7 +88,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "my-prometheus-chart-secrets",
-					Namespace: "monitoring",
+					Namespace: "giantswarm",
 					Labels: map[string]string{
 						label.ManagedBy: "app-operator",
 					},
@@ -383,6 +383,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				K8sClient: clientgofake.NewSimpleClientset(objs...),
 				Logger:    microloggertest.New(),
 
+				ChartNamespace: "giantswarm",
 				ProjectName:    "app-operator",
 				WatchNamespace: "default",
 			}

--- a/service/controller/app/v1/resource/secret/resource.go
+++ b/service/controller/app/v1/resource/secret/resource.go
@@ -23,6 +23,7 @@ type Config struct {
 	Logger    micrologger.Logger
 
 	// Settings.
+	ChartNamespace string
 	ProjectName    string
 	WatchNamespace string
 }
@@ -35,6 +36,7 @@ type Resource struct {
 	logger    micrologger.Logger
 
 	// Settings.
+	chartNamespace string
 	projectName    string
 	watchNamespace string
 }
@@ -51,6 +53,9 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
+	if config.ChartNamespace == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ChartNamespace must not be empty", config)
+	}
 	if config.ProjectName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ProjectName must not be empty", config)
 	}
@@ -60,6 +65,7 @@ func New(config Config) (*Resource, error) {
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
 
+		chartNamespace: config.ChartNamespace,
 		projectName:    config.ProjectName,
 		watchNamespace: config.WatchNamespace,
 	}

--- a/service/controller/app/v1/resource/secret/update_test.go
+++ b/service/controller/app/v1/resource/secret/update_test.go
@@ -135,6 +135,7 @@ func Test_Resource_newUpdateChange(t *testing.T) {
 		K8sClient: clientgofake.NewSimpleClientset(),
 		Logger:    microloggertest.New(),
 
+		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
 		WatchNamespace: "default",
 	}

--- a/service/controller/app/v1/resource_set.go
+++ b/service/controller/app/v1/resource_set.go
@@ -115,6 +115,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 
+			ChartNamespace: config.ChartNamespace,
 			ProjectName:    config.ProjectName,
 			WatchNamespace: config.WatchNamespace,
 		}
@@ -137,6 +138,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 
+			ChartNamespace: config.ChartNamespace,
 			ProjectName:    config.ProjectName,
 			WatchNamespace: config.WatchNamespace,
 		}


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/5930

- This patch is for install `configmap`, `secret` into the same namespace where `chart` would be installed. 