### PR TITLE
configmap & secret namespace fix

### DIFF
--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -27,7 +27,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	config := generateConfig(cr, cc.AppCatalog)
+	config := generateConfig(cr, cc.AppCatalog, r.chartNamespace)
 	tarballURL, err := generateTarballURL(appcatalogkey.AppCatalogStorageURL(cc.AppCatalog), key.AppName(cr), key.Version(cr))
 	if err != nil {
 		return nil, err
@@ -54,13 +54,13 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	return chartCR, nil
 }
 
-func generateConfig(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog) v1alpha1.ChartSpecConfig {
+func generateConfig(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog, chartNamespace string) v1alpha1.ChartSpecConfig {
 	config := v1alpha1.ChartSpecConfig{}
 
 	if hasConfigMap(cr, appCatalog) {
 		configMap := v1alpha1.ChartSpecConfigConfigMap{
 			Name:      key.ChartConfigMapName(cr),
-			Namespace: key.Namespace(cr),
+			Namespace: chartNamespace,
 		}
 
 		config.ConfigMap = configMap
@@ -69,7 +69,7 @@ func generateConfig(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog) v1alpha1.Ch
 	if hasSecret(cr, appCatalog) {
 		secret := v1alpha1.ChartSpecConfigSecret{
 			Name:      key.ChartSecretName(cr),
-			Namespace: key.Namespace(cr),
+			Namespace: chartNamespace,
 		}
 
 		config.Secret = secret

--- a/service/controller/app/v1/resource/chart/desired_test.go
+++ b/service/controller/app/v1/resource/chart/desired_test.go
@@ -89,7 +89,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Config: v1alpha1.ChartSpecConfig{
 						ConfigMap: v1alpha1.ChartSpecConfigConfigMap{
 							Name:      "my-cool-prometheus-chart-values",
-							Namespace: "monitoring",
+							Namespace: "giantswarm",
 						},
 					},
 					Name:       "my-cool-prometheus",
@@ -392,7 +392,7 @@ func Test_generateConfig(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := generateConfig(tc.cr, tc.appCatalog)
+			result := generateConfig(tc.cr, tc.appCatalog, "giantswarm")
 
 			if !reflect.DeepEqual(result, tc.expectedConfig) {
 				t.Fatalf("want matching Config \n %s", cmp.Diff(result, tc.expectedConfig))


### PR DESCRIPTION
- Fix the problem which having wrong namespace in chart.configmap, chart.secret. 
- It should always follow the namespace of `chart`