### PR TITLE
Fixing the current namespace of ConfigMap & Secret

### DIFF
--- a/service/controller/app/v1/resource/configmap/current.go
+++ b/service/controller/app/v1/resource/configmap/current.go
@@ -19,25 +19,24 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	name := key.ChartConfigMapName(cr)
-	namespace := key.Namespace(cr)
 
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding configmap %#q in namespace %#q", name, namespace))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding configmap %#q in namespace %#q", name, r.chartNamespace))
 
-	chart, err := cc.K8sClient.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
+	chart, err := cc.K8sClient.CoreV1().ConfigMaps(r.chartNamespace).Get(name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		// Return early as configmap does not exist.
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find configmap %#q in namespace %#q", name, namespace))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find configmap %#q in namespace %#q", name, r.chartNamespace))
 		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found configmap %#q in namespace %#q", name, namespace))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found configmap %#q in namespace %#q", name, r.chartNamespace))
 
 	return chart, nil
 }

--- a/service/controller/app/v1/resource/configmap/current_test.go
+++ b/service/controller/app/v1/resource/configmap/current_test.go
@@ -48,7 +48,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-app-chart-values",
-					Namespace: "kube-system",
+					Namespace: "giantswarm",
 				},
 			},
 			expectedConfigMap: &corev1.ConfigMap{
@@ -57,7 +57,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-app-chart-values",
-					Namespace: "kube-system",
+					Namespace: "giantswarm",
 				},
 			},
 		},

--- a/service/controller/app/v1/resource/secret/current.go
+++ b/service/controller/app/v1/resource/secret/current.go
@@ -19,25 +19,24 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	name := key.ChartSecretName(cr)
-	namespace := key.Namespace(cr)
 
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding secret %#q in namespace %#q", name, namespace))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding secret %#q in namespace %#q", name, r.chartNamespace))
 
-	chart, err := cc.K8sClient.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+	chart, err := cc.K8sClient.CoreV1().Secrets(r.chartNamespace).Get(name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		// Return early as secret does not exist.
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find secret %#q in namespace %#q", name, namespace))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find secret %#q in namespace %#q", name, r.chartNamespace))
 		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found secret %#q in namespace %#q", name, namespace))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found secret %#q in namespace %#q", name, r.chartNamespace))
 
 	return chart, nil
 }

--- a/service/controller/app/v1/resource/secret/current_test.go
+++ b/service/controller/app/v1/resource/secret/current_test.go
@@ -48,7 +48,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-app-chart-secrets",
-					Namespace: "kube-system",
+					Namespace: "giantswarm",
 				},
 			},
 			expectedSecret: &corev1.Secret{
@@ -57,7 +57,7 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-app-chart-secrets",
-					Namespace: "kube-system",
+					Namespace: "giantswarm",
 				},
 			},
 		},


### PR DESCRIPTION
- @webwurst found an issue when he presents a demo to the customer. 
- Fix the `GetCurrentState` namespace as same as the desired state. 
