### PR TITLE
Clear status when chart is not ready

### DIFF
--- a/service/controller/app/v1/resource/status/create_test.go
+++ b/service/controller/app/v1/resource/status/create_test.go
@@ -132,7 +132,7 @@ func Test_Resource_EnsureCreated(t *testing.T) {
 					APIVersion: "application.giantswarm.io",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "prometheus",
+					Name:      "my-cool-prometheus",
 					Namespace: "default",
 					Labels: map[string]string{
 						"app":                                  "prometheus",


### PR DESCRIPTION
- When the operator could not find related `chart`, it should clear status in `app` CR so the user would not misunderstand the current situation. 