### PR TITLE
Update getCurrentState logic to not report errors when Tenant API is down

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -133,7 +133,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:73215600773eac8399396c41e888a01d9f64a5ebdf8d3c381533f8793c2f2326"
+  digest = "1:9f4e97a0cad42efcb513103b11a4d3cab1866daf46bbcc975b5ca210c71c5421"
   name = "github.com/giantswarm/apiextensions"
   packages = [
     "pkg/apis/application/v1alpha1",
@@ -208,9 +208,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:21b55eca1f822f4a2b5eb42c789b25565ee6affdade65ae6015144ee2a9398ec"
+  digest = "1:08119f5e0765ddd55378346afcc64c074200e3c267aa460f8f4ae81c5bae877c"
   name = "github.com/giantswarm/errors"
-  packages = ["guest"]
+  packages = [
+    "guest",
+    "tenant",
+  ]
   pruneopts = "UT"
   revision = "f6706eb80f388ce182dcee855eab59c5eb872119"
 
@@ -322,7 +325,6 @@
     "flag/service/kubernetes/watch",
     "informer",
     "informer/collector",
-    "resource/configmap",
   ]
   pruneopts = "UT"
   revision = "dc60ddf19e89ce0a1ade4a52e94258734bf82dab"
@@ -1234,6 +1236,7 @@
     "github.com/giantswarm/e2e-harness/pkg/release",
     "github.com/giantswarm/e2esetup/k8s",
     "github.com/giantswarm/e2etemplates/pkg/chartvalues",
+    "github.com/giantswarm/errors/tenant",
     "github.com/giantswarm/exporterkit/collector",
     "github.com/giantswarm/helmclient",
     "github.com/giantswarm/kubeconfig",
@@ -1253,7 +1256,6 @@
     "github.com/giantswarm/operatorkit/controller/resource/retryresource",
     "github.com/giantswarm/operatorkit/flag/service/kubernetes",
     "github.com/giantswarm/operatorkit/informer",
-    "github.com/giantswarm/operatorkit/resource/configmap",
     "github.com/giantswarm/versionbundle",
     "github.com/google/go-cmp/cmp",
     "github.com/prometheus/client_golang/prometheus",

--- a/service/controller/app/v1/resource/chart/current.go
+++ b/service/controller/app/v1/resource/chart/current.go
@@ -33,7 +33,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find chart %#q in namespace %#q", name, r.chartNamespace))
 		return nil, nil
 	} else if tenant.IsAPINotAvailable(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("could not find chart %#q in namespace %#q", name, r.chartNamespace))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find chart %#q in namespace %#q", name, r.chartNamespace))
 		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)

--- a/service/controller/app/v1/resource/chart/delete.go
+++ b/service/controller/app/v1/resource/chart/delete.go
@@ -40,37 +40,22 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 }
 
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
-	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	del, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
 	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
+	patch.SetDeleteChange(del)
 
 	return patch, nil
 }
 
 func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	currentChart, err := toChart(currentState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
 	desiredChart, err := toChart(desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding out if the %#q chart has to be deleted", desiredChart.Name))
-
-	isModified := !isEmpty(currentChart) && equals(currentChart, desiredChart)
-	if isModified {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %#q chart needs to be deleted", desiredChart.Name))
-
-		return desiredChart, nil
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %#q chart does not need to be deleted", desiredChart.Name))
-	}
-
-	return nil, nil
+	return desiredChart, nil
 }

--- a/service/controller/app/v1/resource/chart/delete_test.go
+++ b/service/controller/app/v1/resource/chart/delete_test.go
@@ -58,33 +58,6 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "case 2: chart should not deleted",
-			currentResource: &v1alpha1.Chart{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "prometheus",
-				},
-				Spec: v1alpha1.ChartSpec{
-					Name:       "my-cool-prometheus",
-					Namespace:  "monitoring",
-					TarballURL: "https://giantswarm.github.com/app-catalog/kubernetes-prometheus-1.0.0.tgz",
-				},
-			},
-			desiredResource: &v1alpha1.Chart{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "prometheus",
-					Labels: map[string]string{
-						"app": "prometheus-1",
-					},
-				},
-				Spec: v1alpha1.ChartSpec{
-					Name:       "my-cool-prometheus",
-					Namespace:  "monitoring",
-					TarballURL: "https://giantswarm.github.com/app-catalog/kubernetes-prometheus-1.0.0.tgz",
-				},
-			},
-			expectedChart: &v1alpha1.Chart{},
-		},
 	}
 
 	c := Config{

--- a/service/controller/app/v1/resource/configmap/current.go
+++ b/service/controller/app/v1/resource/configmap/current.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +32,9 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	if apierrors.IsNotFound(err) {
 		// Return early as configmap does not exist.
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find configmap %#q in namespace %#q", name, r.chartNamespace))
+		return nil, nil
+	} else if tenant.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("could not find configmap %#q in namespace %#q", name, r.chartNamespace))
 		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)

--- a/service/controller/app/v1/resource/configmap/current.go
+++ b/service/controller/app/v1/resource/configmap/current.go
@@ -34,7 +34,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find configmap %#q in namespace %#q", name, r.chartNamespace))
 		return nil, nil
 	} else if tenant.IsAPINotAvailable(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("could not find configmap %#q in namespace %#q", name, r.chartNamespace))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find configmap %#q in namespace %#q", name, r.chartNamespace))
 		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)

--- a/service/controller/app/v1/resource/configmap/delete.go
+++ b/service/controller/app/v1/resource/configmap/delete.go
@@ -40,37 +40,22 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 }
 
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
-	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	del, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
 	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
+	patch.SetDeleteChange(del)
 
 	return patch, nil
 }
 
 func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	currentConfigMap, err := toConfigMap(currentState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
 	desiredConfigMap, err := toConfigMap(desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the configMap has to be deleted")
-
-	isModified := !isEmpty(currentConfigMap) && equals(currentConfigMap, desiredConfigMap)
-	if isModified {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "the configMap needs to be deleted")
-
-		return desiredConfigMap, nil
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "the configMap does not need to be deleted")
-	}
-
-	return nil, nil
+	return desiredConfigMap, nil
 }

--- a/service/controller/app/v1/resource/configmap/delete_test.go
+++ b/service/controller/app/v1/resource/configmap/delete_test.go
@@ -29,7 +29,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 			expectedConfigMap: &corev1.ConfigMap{},
 		},
 		{
-			name: "case 1: non empty current and desired, expected desired",
+			name: "case 1: non empty current and empty desired, expected empty",
 			currentState: &corev1.ConfigMap{
 				Data: map[string]string{
 					"key": "value",
@@ -39,46 +39,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			desiredState: &corev1.ConfigMap{
-				Data: map[string]string{
-					"key": "value",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-values",
-					Namespace: "default",
-				},
-			},
-			expectedConfigMap: &corev1.ConfigMap{
-				Data: map[string]string{
-					"key": "value",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-values",
-					Namespace: "default",
-				},
-			},
-		},
-		{
-			name: "case 2: different current and desired, expected empty",
-			currentState: &corev1.ConfigMap{
-				Data: map[string]string{
-					"another": "value",
-					"key":     "value",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-values",
-					Namespace: "default",
-				},
-			},
-			desiredState: &corev1.ConfigMap{
-				Data: map[string]string{
-					"key": "value",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-values",
-					Namespace: "default",
-				},
-			},
+			desiredState:      &corev1.ConfigMap{},
 			expectedConfigMap: &corev1.ConfigMap{},
 		},
 	}

--- a/service/controller/app/v1/resource/secret/current.go
+++ b/service/controller/app/v1/resource/secret/current.go
@@ -34,7 +34,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find secret %#q in namespace %#q", name, r.chartNamespace))
 		return nil, nil
 	} else if tenant.IsAPINotAvailable(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("could not find secret %#q in namespace %#q", name, r.chartNamespace))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find secret %#q in namespace %#q", name, r.chartNamespace))
 		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)

--- a/service/controller/app/v1/resource/secret/current.go
+++ b/service/controller/app/v1/resource/secret/current.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +32,9 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	if apierrors.IsNotFound(err) {
 		// Return early as secret does not exist.
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find secret %#q in namespace %#q", name, r.chartNamespace))
+		return nil, nil
+	} else if tenant.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("could not find secret %#q in namespace %#q", name, r.chartNamespace))
 		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)

--- a/service/controller/app/v1/resource/secret/delete.go
+++ b/service/controller/app/v1/resource/secret/delete.go
@@ -40,37 +40,22 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 }
 
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
-	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	del, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
 	patch := controller.NewPatch()
-	patch.SetDeleteChange(delete)
+	patch.SetDeleteChange(del)
 
 	return patch, nil
 }
 
 func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
-	currentSecret, err := toSecret(currentState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
 	desiredSecret, err := toSecret(desiredState)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the secret has to be deleted")
-
-	isModified := !isEmpty(currentSecret) && equals(currentSecret, desiredSecret)
-	if isModified {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "the secret needs to be deleted")
-
-		return desiredSecret, nil
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "the secret does not need to be deleted")
-	}
-
-	return nil, nil
+	return desiredSecret, nil
 }

--- a/service/controller/app/v1/resource/secret/delete_test.go
+++ b/service/controller/app/v1/resource/secret/delete_test.go
@@ -29,7 +29,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 			expectedSecret: &corev1.Secret{},
 		},
 		{
-			name: "case 1: non empty current and desired, expected desired",
+			name: "case 1: non empty current and empty desired, expected empty",
 			currentState: &corev1.Secret{
 				Data: map[string][]byte{
 					"key": []byte("value"),
@@ -39,46 +39,7 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 					Namespace: "default",
 				},
 			},
-			desiredState: &corev1.Secret{
-				Data: map[string][]byte{
-					"key": []byte("value"),
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-values",
-					Namespace: "default",
-				},
-			},
-			expectedSecret: &corev1.Secret{
-				Data: map[string][]byte{
-					"key": []byte("value"),
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-values",
-					Namespace: "default",
-				},
-			},
-		},
-		{
-			name: "case 2: different current and desired, expected empty",
-			currentState: &corev1.Secret{
-				Data: map[string][]byte{
-					"another": []byte("value"),
-					"key":     []byte("value"),
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-values",
-					Namespace: "default",
-				},
-			},
-			desiredState: &corev1.Secret{
-				Data: map[string][]byte{
-					"key": []byte("value"),
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "app-values",
-					Namespace: "default",
-				},
-			},
+			desiredState:   &corev1.Secret{},
 			expectedSecret: &corev1.Secret{},
 		},
 	}

--- a/vendor/github.com/giantswarm/errors/tenant/error.go
+++ b/vendor/github.com/giantswarm/errors/tenant/error.go
@@ -1,0 +1,56 @@
+package tenant
+
+import (
+	"regexp"
+
+	"github.com/giantswarm/microerror"
+)
+
+var (
+	APINotAvailablePatterns = []*regexp.Regexp{
+		// A regular expression representing DNS errors for the tenant API domain.
+		regexp.MustCompile(`dial tcp: lookup .* on .*:53: (no such host|server misbehaving)`),
+		// A regular expression representing EOF errors for the tenant API domain.
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/nodes.* (unexpected )?EOF`),
+		// A regular expression representing EOF errors for the tenant API domain.
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/namespaces/*/.* (unexpected )?EOF`),
+		// A regular expression representing TLS errors related to establishing
+		// connections to tenant clusters while the tenant API is not fully up.
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..*/api/v1/nodes.* net/http: (TLS handshake timeout|request canceled).*?`),
+		// A regular expression representing timeout errors related to establishing
+		// TCP connections to tenant clusters while the tenant API is not fully up.
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..* dial tcp .* i/o timeout`),
+		// A regular expression representing the kind of transient errors related to
+		// certificates returned while the tenant API is not fully up.
+		regexp.MustCompile(`[Get|Patch|Post] https://api\..*: x509: (certificate is valid for ingress.local, not api\..*|certificate signed by unknown authority \(possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate.*?\))`),
+	}
+)
+
+// APINotAvailableError is returned when the tenant Kubernetes API is not
+// available.
+var APINotAvailableError = &microerror.Error{
+	Kind: "APINotAvailableError",
+}
+
+// IsAPINotAvailable asserts APINotAvailableError.
+func IsAPINotAvailable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	for _, re := range APINotAvailablePatterns {
+		matched := re.MatchString(c.Error())
+
+		if matched {
+			return true
+		}
+	}
+
+	if c == APINotAvailableError {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
- Make `GetCurrentState` to not report error when it's about tenant k8s API 
- Drop complicated comparison logic in deletion. 

To resolve https://github.com/giantswarm/giantswarm/issues/5979