### PR TITLE
app/v1/key: make finalizer prefix longer to avoid conflicts

### DIFF
--- a/service/controller/app/v1/key/key.go
+++ b/service/controller/app/v1/key/key.go
@@ -66,7 +66,7 @@ func InCluster(customResource v1alpha1.App) bool {
 }
 
 func KubeConfigFinalizer(customResource v1alpha1.App) string {
-	return fmt.Sprintf("app-operator.giantswarm.io/%s", customResource.GetName())
+	return fmt.Sprintf("app-operator.giantswarm.io/app-%s", customResource.GetName())
 }
 
 func KubecConfigSecretName(customResource v1alpha1.App) string {

--- a/service/controller/app/v1/key/key_test.go
+++ b/service/controller/app/v1/key/key_test.go
@@ -212,7 +212,7 @@ func Test_KubecConfigFinalizer(t *testing.T) {
 	}
 
 	if KubeConfigFinalizer(obj) != "app-operator.giantswarm.io/app-my-test-app" {
-		t.Fatalf("kubeconfig finalizer name %#v, want %#v", KubeConfigFinalizer(obj), "app-operator.giantswarm.io/my-test-app")
+		t.Fatalf("kubeconfig finalizer name %#v, want %#v", KubeConfigFinalizer(obj), "app-operator.giantswarm.io/app-my-test-app")
 	}
 }
 

--- a/service/controller/app/v1/key/key_test.go
+++ b/service/controller/app/v1/key/key_test.go
@@ -211,7 +211,7 @@ func Test_KubecConfigFinalizer(t *testing.T) {
 		},
 	}
 
-	if KubeConfigFinalizer(obj) != "app-operator.giantswarm.io/my-test-app" {
+	if KubeConfigFinalizer(obj) != "app-operator.giantswarm.io/app-my-test-app" {
 		t.Fatalf("kubeconfig finalizer name %#v, want %#v", KubeConfigFinalizer(obj), "app-operator.giantswarm.io/my-test-app")
 	}
 }


### PR DESCRIPTION
I asked for that in the original PR. I think this is reasonable to make
this prefix a bit longer since app names are arbitrary. That may (even
though unlikely) cause conflicts with finalizers added in the future.