### PR TITLE
Use alpine 3.9 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
I noticed this when doing the docs PR earlier. Getting it straight.

Not sure how important updating the other 3.8 images is?