### PR TITLE
Resource cancelling when timeout & tenant API down

### DIFF
--- a/service/controller/app/v1/resource/configmap/create.go
+++ b/service/controller/app/v1/resource/configmap/create.go
@@ -11,15 +11,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
-	"github.com/giantswarm/app-operator/service/controller/app/v1/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
-	cr, err := key.ToCustomResource(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	configMap, err := toConfigMap(createChange)
 	if err != nil {
 		return microerror.Mask(err)
@@ -36,16 +30,8 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		_, err = cc.K8sClient.CoreV1().ConfigMaps(configMap.Namespace).Create(configMap)
 		if apierrors.IsAlreadyExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created configmap %#q in namespace %#q", configMap.Name, configMap.Namespace))
-		} else if apierrors.IsTimeout(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "cluster api timeout.")
-
-			// We should not hammer API if it is not available, the cluster
-			// might be initializing. We will retry on next reconciliation loop.
-			resourcecanceledcontext.SetCanceled(ctx)
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-
 			return nil
-		} else if !key.InCluster(cr) && tenant.IsAPINotAvailable(err) {
+		} else if tenant.IsAPINotAvailable(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available.")
 
 			// We should not hammer tenant API if it is not available, the tenant cluster

--- a/service/controller/app/v1/resource/configmap/create.go
+++ b/service/controller/app/v1/resource/configmap/create.go
@@ -16,6 +16,10 @@ import (
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
 	cr, err := key.ToCustomResource(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	configMap, err := toConfigMap(createChange)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/app/v1/resource/configmap/create.go
+++ b/service/controller/app/v1/resource/configmap/create.go
@@ -30,7 +30,6 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		_, err = cc.K8sClient.CoreV1().ConfigMaps(configMap.Namespace).Create(configMap)
 		if apierrors.IsAlreadyExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created configmap %#q in namespace %#q", configMap.Name, configMap.Namespace))
-			return nil
 		} else if tenant.IsAPINotAvailable(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available.")
 

--- a/service/controller/app/v1/resource/configmap/create.go
+++ b/service/controller/app/v1/resource/configmap/create.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
+	"github.com/giantswarm/app-operator/service/controller/app/v1/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	cr, err := key.ToCustomResource(obj)
 	configMap, err := toConfigMap(createChange)
 	if err != nil {
 		return microerror.Mask(err)
@@ -28,6 +32,24 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		_, err = cc.K8sClient.CoreV1().ConfigMaps(configMap.Namespace).Create(configMap)
 		if apierrors.IsAlreadyExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created configmap %#q in namespace %#q", configMap.Name, configMap.Namespace))
+		} else if apierrors.IsTimeout(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "cluster api timeout.")
+
+			// We should not hammer API if it is not available, the cluster
+			// might be initializing. We will retry on next reconciliation loop.
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if !key.InCluster(cr) && tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available.")
+
+			// We should not hammer tenant API if it is not available, the tenant cluster
+			// might be initializing. We will retry on next reconciliation loop.
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {

--- a/service/controller/app/v1/resource/configmap/current.go
+++ b/service/controller/app/v1/resource/configmap/current.go
@@ -34,16 +34,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		// Return early as configmap does not exist.
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find configmap %#q in namespace %#q", name, r.chartNamespace))
 		return nil, nil
-	} else if apierrors.IsTimeout(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "cluster api timeout.")
-
-		// We should not hammer API if it is not available, the cluster
-		// might be initializing. We will retry on next reconciliation loop.
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-
-		return nil, nil
-	} else if !key.InCluster(cr) && tenant.IsAPINotAvailable(err) {
+	} else if tenant.IsAPINotAvailable(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available.")
 
 		// We should not hammer tenant API if it is not available, the tenant cluster

--- a/service/controller/app/v1/resource/secret/create.go
+++ b/service/controller/app/v1/resource/secret/create.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -28,6 +30,15 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		_, err = cc.K8sClient.CoreV1().Secrets(secret.Namespace).Create(secret)
 		if apierrors.IsAlreadyExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created secret %#q in namespace %#q", secret.Name, secret.Namespace))
+		} else if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available.")
+
+			// We should not hammer tenant API if it is not available, the tenant cluster
+			// might be initializing. We will retry on next reconciliation loop.
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {

--- a/service/controller/app/v1/resource/status/create.go
+++ b/service/controller/app/v1/resource/status/create.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -32,8 +34,17 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if errors.IsNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find chart %#q in namespace %#q", name, r.chartNamespace))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		return nil
 
+		return nil
+	} else if tenant.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available.")
+
+		// We should not hammer tenant API if it is not available, the tenant cluster
+		// might be initializing. We will retry on next reconciliation loop.
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil
 	} else if err != nil {
 		return microerror.Mask(err)
 	}


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/6289

- For this PR, the operator would check whether error matches `Timeout`,`TenantAPIError` cases and would cancel resource reconciliation. 

- First I would like to get approval from `configmap` first and *apply in general to other resources.* 
