### PR TITLE
Copy cordon related annotation into chart CR

### DIFF
--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -4,10 +4,10 @@ package annotation
 
 const (
 	// CordonReason is the name of the annotation that indicates
-	// the reason of why app-operator should not apply any update on this app CR.
+	// the reason of why app-operator should not apply any update to this app CR.
 	CordonReason = "app-operator.giantswarm.io/cordon-reason"
 
 	// CordonUntil is the name of the annotation that indicates
-	// the expiration date of rule of this cordon.
+	// the expiration date for this cordon rule.
 	CordonUntil = "app-operator.giantswarm.io/cordon-until"
 )

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -1,0 +1,13 @@
+// Package annotation contains common Kubernetes metadata. These are defined in
+// https://github.com/giantswarm/fmt/blob/master/kubernetes/annotations_and_labels.md.
+package annotation
+
+const (
+	// CordonReason is the name of the annotation that indicates
+	// the reason of why app-operator should not apply any update on this app CR.
+	CordonReason = "app-operator.giantswarm.io/cordon-reason"
+
+	// CordonUntilDate is the name of the annotation that indicates
+	// the expiration date of rule of this cordon.
+	CordonUntilDate = "app-operator.giantswarm.io/cordon-until"
+)

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -7,7 +7,7 @@ const (
 	// the reason of why app-operator should not apply any update on this app CR.
 	CordonReason = "app-operator.giantswarm.io/cordon-reason"
 
-	// CordonUntilDate is the name of the annotation that indicates
+	// CordonUntil is the name of the annotation that indicates
 	// the expiration date of rule of this cordon.
-	CordonUntilDate = "app-operator.giantswarm.io/cordon-until"
+	CordonUntil = "app-operator.giantswarm.io/cordon-until"
 )

--- a/service/controller/app/v1/key/key.go
+++ b/service/controller/app/v1/key/key.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
 
+	"github.com/giantswarm/app-operator/pkg/annotation"
 	"github.com/giantswarm/app-operator/pkg/label"
 )
 
@@ -61,8 +62,28 @@ func ChartSecretName(customResource v1alpha1.App) string {
 	return fmt.Sprintf("%s-chart-secrets", customResource.GetName())
 }
 
+func CordonReason(customObject v1alpha1.App) string {
+	return customObject.GetAnnotations()[annotation.CordonReason]
+}
+
+func CordonUntil(customObject v1alpha1.App) string {
+	return customObject.GetAnnotations()[annotation.CordonUntilDate]
+}
+
 func InCluster(customResource v1alpha1.App) bool {
 	return customResource.Spec.KubeConfig.InCluster
+}
+
+func IsCordoned(customObject v1alpha1.App) bool {
+	_, reasonOk := customObject.Annotations[annotation.CordonReason]
+	_, untilOk := customObject.Annotations[annotation.CordonUntilDate]
+
+	if reasonOk && untilOk {
+		return true
+	} else {
+		return false
+	}
+
 }
 
 func KubeConfigFinalizer(customResource v1alpha1.App) string {

--- a/service/controller/app/v1/key/key.go
+++ b/service/controller/app/v1/key/key.go
@@ -83,7 +83,6 @@ func IsCordoned(customObject v1alpha1.App) bool {
 	} else {
 		return false
 	}
-
 }
 
 func KubeConfigFinalizer(customResource v1alpha1.App) string {

--- a/service/controller/app/v1/key/key.go
+++ b/service/controller/app/v1/key/key.go
@@ -67,7 +67,7 @@ func CordonReason(customObject v1alpha1.App) string {
 }
 
 func CordonUntil(customObject v1alpha1.App) string {
-	return customObject.GetAnnotations()[annotation.CordonUntilDate]
+	return customObject.GetAnnotations()[annotation.CordonUntil]
 }
 
 func InCluster(customResource v1alpha1.App) bool {
@@ -76,7 +76,7 @@ func InCluster(customResource v1alpha1.App) bool {
 
 func IsCordoned(customObject v1alpha1.App) bool {
 	_, reasonOk := customObject.Annotations[annotation.CordonReason]
-	_, untilOk := customObject.Annotations[annotation.CordonUntilDate]
+	_, untilOk := customObject.Annotations[annotation.CordonUntil]
 
 	if reasonOk && untilOk {
 		return true

--- a/service/controller/app/v1/key/key_test.go
+++ b/service/controller/app/v1/key/key_test.go
@@ -214,7 +214,7 @@ func Test_CordonUntil(t *testing.T) {
 	obj := v1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				annotation.CordonUntilDate: "2019-12-31T23:59:59Z",
+				annotation.CordonUntil: "2019-12-31T23:59:59Z",
 			},
 		},
 	}
@@ -249,8 +249,8 @@ func Test_IsCordoned(t *testing.T) {
 			chart: v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						annotation.CordonReason:    "testing manual upgrade",
-						annotation.CordonUntilDate: "2019-12-31T23:59:59Z",
+						annotation.CordonReason: "testing manual upgrade",
+						annotation.CordonUntil:  "2019-12-31T23:59:59Z",
 					},
 				},
 			},

--- a/service/controller/app/v1/key/key_test.go
+++ b/service/controller/app/v1/key/key_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/app-operator/pkg/annotation"
 )
 
 func Test_AppConfigMapName(t *testing.T) {
@@ -190,6 +192,38 @@ func Test_ChartConfigMapName(t *testing.T) {
 	}
 }
 
+func Test_CordonReason(t *testing.T) {
+	expectedCordonReason := "manual upgrade"
+
+	obj := v1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotation.CordonReason: "manual upgrade",
+			},
+		},
+	}
+
+	if CordonReason(obj) != expectedCordonReason {
+		t.Fatalf("cordon reason %#q, want %s", CordonReason(obj), expectedCordonReason)
+	}
+}
+
+func Test_CordonUntil(t *testing.T) {
+	expectedCordonUntil := "2019-12-31T23:59:59Z"
+
+	obj := v1alpha1.App{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annotation.CordonUntilDate: "2019-12-31T23:59:59Z",
+			},
+		},
+	}
+
+	if CordonUntil(obj) != expectedCordonUntil {
+		t.Fatalf("cordon until %s, want %s", CordonUntil(obj), expectedCordonUntil)
+	}
+}
+
 func Test_InCluster(t *testing.T) {
 	obj := v1alpha1.App{
 		Spec: v1alpha1.AppSpec{
@@ -201,6 +235,39 @@ func Test_InCluster(t *testing.T) {
 
 	if !InCluster(obj) {
 		t.Fatalf("app namespace %#v, want %#v", InCluster(obj), true)
+	}
+}
+
+func Test_IsCordoned(t *testing.T) {
+	tests := []struct {
+		name           string
+		chart          v1alpha1.App
+		expectedResult bool
+	}{
+		{
+			name: "case 0: app cordoned",
+			chart: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotation.CordonReason:    "testing manual upgrade",
+						annotation.CordonUntilDate: "2019-12-31T23:59:59Z",
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name:           "case 1: chart did not cordon",
+			chart:          v1alpha1.App{},
+			expectedResult: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCordoned(tt.chart); got != tt.expectedResult {
+				t.Errorf("IsCordoned() = %v, want %v", got, tt.expectedResult)
+			}
+		})
 	}
 }
 

--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -110,7 +110,7 @@ func hasSecret(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog) bool {
 }
 
 func replacePrefix(from string) string {
-	return strings.ReplaceAll(from, "app-operator.giantswarm.io", "chart-operator.giantswarm.io")
+	return strings.Replace(from, "app-operator.giantswarm.io", "chart-operator.giantswarm.io", 1)
 }
 
 // processAnnotations ensures necessary app-operator.giantswarm.io annotations

--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -116,7 +116,6 @@ func replacePrefix(from string) string {
 // processAnnotations ensures necessary app-operator.giantswarm.io annotations
 // are copied into the proper prefix in chart CR.
 func processAnnotations(cr v1alpha1.App) map[string]string {
-
 	if cr.GetAnnotations() == nil {
 		return nil
 	}

--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/app-operator/pkg/annotation"
 	"github.com/giantswarm/app-operator/pkg/label"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/key"
@@ -39,9 +41,10 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			APIVersion: chartAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.GetName(),
-			Namespace: r.chartNamespace,
-			Labels:    processLabels(r.projectName, cr.GetLabels()),
+			Annotations: processAnnotations(cr),
+			Name:        cr.GetName(),
+			Namespace:   r.chartNamespace,
+			Labels:      processLabels(r.projectName, cr.GetLabels()),
 		},
 		Spec: v1alpha1.ChartSpec{
 			Config:     config,
@@ -104,6 +107,31 @@ func hasSecret(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog) bool {
 	}
 
 	return false
+}
+
+func replacePrefix(from string) string {
+	return strings.ReplaceAll(from, "app-operator.giantswarm.io", "chart-operator.giantswarm.io")
+}
+
+// processAnnotations ensures necessary app-operator.giantswarm.io annotations
+// are copied into the proper prefix in chart CR.
+func processAnnotations(cr v1alpha1.App) map[string]string {
+
+	if cr.GetAnnotations() == nil {
+		return nil
+	}
+
+	newAnnotations := map[string]string{}
+
+	if key.IsCordoned(cr) {
+		cordonReasonKey := replacePrefix(annotation.CordonReason)
+		newAnnotations[cordonReasonKey] = key.CordonReason(cr)
+
+		cordonUntilKey := replacePrefix(annotation.CordonUntilDate)
+		newAnnotations[cordonUntilKey] = key.CordonUntil(cr)
+	}
+
+	return newAnnotations
 }
 
 // processLabels ensures the chart-operator.giantswarm.io/version label is

--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -127,7 +127,7 @@ func processAnnotations(cr v1alpha1.App) map[string]string {
 		cordonReasonKey := replacePrefix(annotation.CordonReason)
 		newAnnotations[cordonReasonKey] = key.CordonReason(cr)
 
-		cordonUntilKey := replacePrefix(annotation.CordonUntilDate)
+		cordonUntilKey := replacePrefix(annotation.CordonUntil)
 		newAnnotations[cordonUntilKey] = key.CordonUntil(cr)
 	}
 

--- a/service/controller/app/v1/resource/chart/desired_test.go
+++ b/service/controller/app/v1/resource/chart/desired_test.go
@@ -155,8 +155,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 			obj: &v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						annotation.CordonReason:    "migrating job in process",
-						annotation.CordonUntilDate: "2019-12-31T23:59:59Z",
+						annotation.CordonReason: "migrating job in process",
+						annotation.CordonUntil:  "2019-12-31T23:59:59Z",
 					},
 					Name:      "my-cool-prometheus",
 					Namespace: "default",

--- a/service/controller/app/v1/resource/chart/desired_test.go
+++ b/service/controller/app/v1/resource/chart/desired_test.go
@@ -570,6 +570,21 @@ func Test_processAnnotations(t *testing.T) {
 				"chart-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
 			},
 		},
+		{
+			name: "case 1: filter other annotations",
+			obj: &v1alpha1.App{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Chart",
+					APIVersion: "application.giantswarm.io",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubectl.kubernetes.io/last-applied-configuration": "application.giantswarm.io/v1alpha1",
+					},
+				},
+			},
+			expectedAnnotations: map[string]string{},
+		},
 	}
 
 	for _, tc := range tests {

--- a/service/controller/app/v1/resource/chart/desired_test.go
+++ b/service/controller/app/v1/resource/chart/desired_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/app-operator/pkg/annotation"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
 )
 
@@ -148,6 +149,90 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				},
 			},
 			errorMatcher: IsExecutionFailed,
+		},
+		{
+			name: "case 2: cordoned app",
+			obj: &v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						annotation.CordonReason:    "migrating job in process",
+						annotation.CordonUntilDate: "2019-12-31T23:59:59Z",
+					},
+					Name:      "my-cool-prometheus",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                                "prometheus",
+						"app-operator.giantswarm.io/version": "1.0.0",
+						"giantswarm.io/managed-by":           "cluster-operator",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "kubernetes-prometheus",
+					Namespace: "monitoring",
+					Version:   "1.0.0",
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "giant-swarm-config",
+							Namespace: "giantswarm",
+						},
+					},
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						Secret: v1alpha1.AppSpecKubeConfigSecret{
+							Name:      "giantswarm-12345",
+							Namespace: "12345",
+						},
+					},
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "giantswarm",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app-operator.giantswarm.io/version": "1.0.0",
+					},
+				},
+				Spec: v1alpha1.AppCatalogSpec{
+					Title:       "Giant Swarm",
+					Description: "Catalog of Apps by Giant Swarm",
+					Storage: v1alpha1.AppCatalogSpecStorage{
+						Type: "helm",
+						URL:  "https://giantswarm.github.com/app-catalog/",
+					},
+					LogoURL: "https://s.giantswarm.io/...",
+				},
+			},
+			expectedChart: &v1alpha1.Chart{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Chart",
+					APIVersion: "application.giantswarm.io",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"chart-operator.giantswarm.io/cordon-reason": "migrating job in process",
+						"chart-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
+					},
+					Name:      "my-cool-prometheus",
+					Namespace: "giantswarm",
+					Labels: map[string]string{
+						"app":                                  "prometheus",
+						"chart-operator.giantswarm.io/version": "1.0.0",
+						"giantswarm.io/managed-by":             "app-operator",
+					},
+				},
+				Spec: v1alpha1.ChartSpec{
+					Config: v1alpha1.ChartSpecConfig{
+						ConfigMap: v1alpha1.ChartSpecConfigConfigMap{
+							Name:      "my-cool-prometheus-chart-values",
+							Namespace: "giantswarm",
+						},
+					},
+					Name:       "my-cool-prometheus",
+					Namespace:  "monitoring",
+					TarballURL: "https://giantswarm.github.com/app-catalog/kubernetes-prometheus-1.0.0.tgz",
+				},
+			},
 		},
 	}
 
@@ -455,6 +540,45 @@ func Test_processLabels(t *testing.T) {
 
 			if !reflect.DeepEqual(result, tc.expectedLabels) {
 				t.Fatalf("want matching \n %s", cmp.Diff(result, tc.expectedLabels))
+			}
+		})
+	}
+}
+
+func Test_processAnnotations(t *testing.T) {
+	tests := []struct {
+		name                string
+		obj                 *v1alpha1.App
+		expectedAnnotations map[string]string
+	}{
+		{
+			name: "case 0: basic match",
+			obj: &v1alpha1.App{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Chart",
+					APIVersion: "application.giantswarm.io",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"app-operator.giantswarm.io/cordon-reason": "migrating job in process",
+						"app-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
+					},
+				},
+			},
+			expectedAnnotations: map[string]string{
+				"chart-operator.giantswarm.io/cordon-reason": "migrating job in process",
+				"chart-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			result := processAnnotations(*tc.obj)
+
+			if !reflect.DeepEqual(result, tc.expectedAnnotations) {
+				t.Fatalf("want matching \n %s", cmp.Diff(result, tc.expectedAnnotations))
 			}
 		})
 	}


### PR DESCRIPTION
Toward giantswarm/giantswarm#6078

It would copy all annotation from `app` CR into `chart` CR after operator-related prefix changes. 

