### PR TITLE
Update annotation in target chart when cordon updated

### DIFF
--- a/service/controller/app/v1/resource/chart/resource.go
+++ b/service/controller/app/v1/resource/chart/resource.go
@@ -75,15 +75,26 @@ func (r *Resource) Name() string {
 }
 
 // equals asseses the equality of ReleaseStates with regards to distinguishing fields.
-func equals(a, b *v1alpha1.Chart) bool {
-	if a.Name != b.Name {
+func equals(current, desired *v1alpha1.Chart) bool {
+	if current.Name != desired.Name {
 		return false
 	}
-	if !reflect.DeepEqual(a.Spec, b.Spec) {
+	if !reflect.DeepEqual(current.Spec, desired.Spec) {
 		return false
 	}
-	if !reflect.DeepEqual(a.Labels, b.Labels) {
+	if !reflect.DeepEqual(current.Labels, desired.Labels) {
 		return false
+	}
+
+	desiredAnnotation := desired.GetAnnotations()
+	for currentAnnotationKey, currentValue := range current.GetAnnotations() {
+		if desiredValue, ok := desiredAnnotation[currentAnnotationKey]; ok {
+			if currentValue != desiredValue {
+				return false
+			}
+		} else {
+			return false
+		}
 	}
 	return true
 }

--- a/service/controller/app/v1/resource/chart/resource.go
+++ b/service/controller/app/v1/resource/chart/resource.go
@@ -86,9 +86,9 @@ func equals(current, desired *v1alpha1.Chart) bool {
 		return false
 	}
 
-	desiredAnnotation := desired.GetAnnotations()
-	for currentAnnotationKey, currentValue := range current.GetAnnotations() {
-		if desiredValue, ok := desiredAnnotation[currentAnnotationKey]; ok {
+	desiredAnnotations := desired.GetAnnotations()
+	for currentKey, currentValue := range current.GetAnnotations() {
+		if desiredValue, ok := desiredAnnotations[currentKey]; ok {
 			if currentValue != desiredValue {
 				return false
 			}

--- a/service/controller/app/v1/resource/chart/update_test.go
+++ b/service/controller/app/v1/resource/chart/update_test.go
@@ -76,6 +76,47 @@ func Test_Resource_newUpdateChange(t *testing.T) {
 			},
 			expectedChart: &v1alpha1.Chart{},
 		},
+		{
+			name: "case 1: chart should be update for cordon annotations",
+			currentResource: &v1alpha1.Chart{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"chart-operator.giantswarm.io/values-md5-checksum": "52668444a530c7b296f9c620f8cb2632",
+					},
+					Name: "prometheus",
+				},
+				Spec: v1alpha1.ChartSpec{
+					Name:      "my-cool-prometheus",
+					Namespace: "monitoring",
+				},
+			},
+			desiredResource: &v1alpha1.Chart{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"chart-operator.giantswarm.io/cordon-reason": "chart maintenance",
+						"chart-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
+					},
+					Name: "prometheus",
+				},
+				Spec: v1alpha1.ChartSpec{
+					Name:      "my-cool-prometheus",
+					Namespace: "monitoring",
+				},
+			},
+			expectedChart: &v1alpha1.Chart{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"chart-operator.giantswarm.io/cordon-reason": "chart maintenance",
+						"chart-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
+					},
+					Name: "prometheus",
+				},
+				Spec: v1alpha1.ChartSpec{
+					Name:      "my-cool-prometheus",
+					Namespace: "monitoring",
+				},
+			},
+		},
 	}
 
 	c := Config{

--- a/service/controller/app/v1/resource/chart/update_test.go
+++ b/service/controller/app/v1/resource/chart/update_test.go
@@ -53,7 +53,7 @@ func Test_Resource_newUpdateChange(t *testing.T) {
 			},
 		},
 		{
-			name: "case 1: chart should not be update",
+			name: "case 1: chart should not be updated",
 			currentResource: &v1alpha1.Chart{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "prometheus",
@@ -77,7 +77,7 @@ func Test_Resource_newUpdateChange(t *testing.T) {
 			expectedChart: &v1alpha1.Chart{},
 		},
 		{
-			name: "case 1: chart should be update for cordon annotations",
+			name: "case 2: chart should be updated for cordon annotations",
 			currentResource: &v1alpha1.Chart{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{


### PR DESCRIPTION
Following https://github.com/giantswarm/app-operator/pull/104

I found a problem that we do not compare `annotation` values between `current` chart and `desired` chart. 

By this PR, we would compare the cordon annotations between the two charts. 