### PR TITLE
Adding namespace for cordon metrics

### DIFF
--- a/service/collector/app_resource.go
+++ b/service/collector/app_resource.go
@@ -34,6 +34,7 @@ var (
 		"A metric of the expire time of cordoned apps unix seconds.",
 		[]string{
 			labelName,
+			labelNamespace,
 		},
 		nil,
 	)
@@ -128,6 +129,7 @@ func (c *AppResource) collectAppStatus(ctx context.Context, ch chan<- prometheus
 			prometheus.GaugeValue,
 			float64(t.Unix()),
 			key.AppName(app),
+			key.Namespace(app),
 		)
 	}
 	return nil


### PR DESCRIPTION
Toward giantswarm/giantswarm#6078

I would like to diplay below alert message, 
```
Cordoned app {{ $labels.name }} in {{ $labels.namespace }} is expired.
```
but found out operator is not seding `namespace` label information yet. 
