### PR TITLE
Removing kubeconfig finaliser

### DIFF
--- a/service/controller/app/v1/resource/kubeconfigfinalizer/create.go
+++ b/service/controller/app/v1/resource/kubeconfigfinalizer/create.go
@@ -53,18 +53,17 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	finalizerTag := key.KubeConfigFinalizer(cr)
 
 	if !contains(kubeConfig.Finalizers, finalizerTag) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("setting finalizer for kubeconfig %#q in namespace %#q", name, namespace))
-
-		kubeConfig.Finalizers = append(kubeConfig.Finalizers, finalizerTag)
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finalizer already clear for kubeconfig secret %#q in namespace %#q", name, namespace))
+	} else {
+		// TODO: Before we remove this resource, let's delete all finalizers that we put on kubeconfig secrets
+		kubeConfig.Finalizers = filter(kubeConfig.Finalizers, finalizerTag)
 
 		_, err := r.k8sClient.CoreV1().Secrets(namespace).Update(kubeConfig)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finalizer set for kubeconfig %#q in namespace %#q", name, namespace))
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finalizer already set for kubeconfig secret %#q in namespace %#q", name, namespace))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finalizer cleared for kubeconfig %#q in namespace %#q", name, namespace))
 	}
 	return nil
 }

--- a/service/controller/app/v1/resource/kubeconfigfinalizer/create.go
+++ b/service/controller/app/v1/resource/kubeconfigfinalizer/create.go
@@ -55,7 +55,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if !contains(kubeConfig.Finalizers, finalizerTag) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finalizer already unset for kubeconfig secret %#q in namespace %#q", name, namespace))
 	} else {
-		// TODO: Before we remove this resource, let's delete all finalizers that we put on kubeconfig secrets
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing finalizer for kubeconfig secret %#q in namespace %#q", name, namespace))
+
+		// TODO: After modifying all kubeconfig secrets in the installations, delete this resource
+		//     See https://github.com/giantswarm/giantswarm/issues/6522
 		kubeConfig.Finalizers = filter(kubeConfig.Finalizers, finalizerTag)
 
 		_, err := r.k8sClient.CoreV1().Secrets(namespace).Update(kubeConfig)

--- a/service/controller/app/v1/resource/kubeconfigfinalizer/create.go
+++ b/service/controller/app/v1/resource/kubeconfigfinalizer/create.go
@@ -63,7 +63,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finalizer cleared for kubeconfig %#q in namespace %#q", name, namespace))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removed finalizer for kubeconfig secret %#q in namespace %#q", name, namespace))
 	}
 	return nil
 }

--- a/service/controller/app/v1/resource/kubeconfigfinalizer/create.go
+++ b/service/controller/app/v1/resource/kubeconfigfinalizer/create.go
@@ -53,7 +53,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	finalizerTag := key.KubeConfigFinalizer(cr)
 
 	if !contains(kubeConfig.Finalizers, finalizerTag) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finalizer already clear for kubeconfig secret %#q in namespace %#q", name, namespace))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finalizer already unset for kubeconfig secret %#q in namespace %#q", name, namespace))
 	} else {
 		// TODO: Before we remove this resource, let's delete all finalizers that we put on kubeconfig secrets
 		kubeConfig.Finalizers = filter(kubeConfig.Finalizers, finalizerTag)

--- a/service/controller/app/v1/resource/kubeconfigfinalizer/delete.go
+++ b/service/controller/app/v1/resource/kubeconfigfinalizer/delete.go
@@ -2,60 +2,9 @@ package kubeconfigfinalizer
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/giantswarm/microerror"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/giantswarm/app-operator/service/controller/app/v1/key"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	cr, err := key.ToCustomResource(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	if key.InCluster(cr) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q do not use kubeconfig secret", cr.GetName()))
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		return nil
-	}
-
-	name := key.KubecConfigSecretName(cr)
-	namespace := key.KubecConfigSecretNamespace(cr)
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding kubeconfig secret %#q in namespace %#q", name, namespace))
-
-	kubeConfig, err := r.k8sClient.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find kubeconfig secret %#q in namespace %#q", name, namespace))
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		return nil
-
-	} else if err != nil {
-		return microerror.Mask(err)
-	}
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found kubeconfig secret %#q in namespace %#q", name, namespace))
-
-	finalizerTag := key.KubeConfigFinalizer(cr)
-
-	if contains(kubeConfig.Finalizers, finalizerTag) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clear finalizer for kubeconfig secret %#q in namespace %#q", name, namespace))
-
-		kubeConfig.Finalizers = filter(kubeConfig.Finalizers, finalizerTag)
-
-		_, err := r.k8sClient.CoreV1().Secrets(namespace).Update(kubeConfig)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finalizer clear for kubeconfig secret %#q in namespace %#q", name, namespace))
-	} else {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("kubeconfig secret %#q in namespace %#q do not have matching finalizer", name, namespace))
-	}
 	return nil
 }
 


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/6522

We decided to remove this finalizer on the kubeconfig secret resource, and we would implement another logic to avoid reconciling app CRs against soon-deleting clusters. 

Before we remove `kubeconfigfinaliser` resource, we would like to clean up the remaining finaliser. 