### PR TITLE
removing `watchNamespace` from several resource configs

### DIFF
--- a/service/controller/app/v1/resource/configmap/create_test.go
+++ b/service/controller/app/v1/resource/configmap/create_test.go
@@ -98,7 +98,6 @@ func Test_Resource_newCreateChange(t *testing.T) {
 
 		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
-		WatchNamespace: "default",
 	}
 	r, err := New(c)
 	if err != nil {

--- a/service/controller/app/v1/resource/configmap/current_test.go
+++ b/service/controller/app/v1/resource/configmap/current_test.go
@@ -151,7 +151,6 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 
 				ChartNamespace: "giantswarm",
 				ProjectName:    "app-operator",
-				WatchNamespace: "default",
 			}
 			r, err := New(c)
 			if err != nil {

--- a/service/controller/app/v1/resource/configmap/delete_test.go
+++ b/service/controller/app/v1/resource/configmap/delete_test.go
@@ -51,7 +51,6 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 
 		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
-		WatchNamespace: "default",
 	}
 	r, err := New(c)
 	if err != nil {

--- a/service/controller/app/v1/resource/configmap/desired_test.go
+++ b/service/controller/app/v1/resource/configmap/desired_test.go
@@ -383,7 +383,6 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 
 				ChartNamespace: "giantswarm",
 				ProjectName:    "app-operator",
-				WatchNamespace: "default",
 			}
 			r, err := New(c)
 			if err != nil {

--- a/service/controller/app/v1/resource/configmap/resource.go
+++ b/service/controller/app/v1/resource/configmap/resource.go
@@ -25,7 +25,6 @@ type Config struct {
 	// Settings.
 	ChartNamespace string
 	ProjectName    string
-	WatchNamespace string
 }
 
 // Resource implements the configmap resource.
@@ -38,7 +37,6 @@ type Resource struct {
 	// Settings.
 	chartNamespace string
 	projectName    string
-	watchNamespace string
 }
 
 // New creates a new configured configmap resource.
@@ -67,7 +65,6 @@ func New(config Config) (*Resource, error) {
 
 		chartNamespace: config.ChartNamespace,
 		projectName:    config.ProjectName,
-		watchNamespace: config.WatchNamespace,
 	}
 
 	return r, nil

--- a/service/controller/app/v1/resource/configmap/update_test.go
+++ b/service/controller/app/v1/resource/configmap/update_test.go
@@ -137,7 +137,6 @@ func Test_Resource_newUpdateChange(t *testing.T) {
 
 		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
-		WatchNamespace: "default",
 	}
 	r, err := New(c)
 	if err != nil {

--- a/service/controller/app/v1/resource/secret/create_test.go
+++ b/service/controller/app/v1/resource/secret/create_test.go
@@ -98,7 +98,6 @@ func Test_Resource_newCreateChange(t *testing.T) {
 
 		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
-		WatchNamespace: "default",
 	}
 	r, err := New(c)
 	if err != nil {

--- a/service/controller/app/v1/resource/secret/current_test.go
+++ b/service/controller/app/v1/resource/secret/current_test.go
@@ -151,7 +151,6 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 
 				ChartNamespace: "giantswarm",
 				ProjectName:    "app-operator",
-				WatchNamespace: "default",
 			}
 			r, err := New(c)
 			if err != nil {

--- a/service/controller/app/v1/resource/secret/delete_test.go
+++ b/service/controller/app/v1/resource/secret/delete_test.go
@@ -51,7 +51,6 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 
 		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
-		WatchNamespace: "default",
 	}
 	r, err := New(c)
 	if err != nil {

--- a/service/controller/app/v1/resource/secret/desired_test.go
+++ b/service/controller/app/v1/resource/secret/desired_test.go
@@ -385,7 +385,6 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 
 				ChartNamespace: "giantswarm",
 				ProjectName:    "app-operator",
-				WatchNamespace: "default",
 			}
 			r, err := New(c)
 			if err != nil {

--- a/service/controller/app/v1/resource/secret/resource.go
+++ b/service/controller/app/v1/resource/secret/resource.go
@@ -25,7 +25,6 @@ type Config struct {
 	// Settings.
 	ChartNamespace string
 	ProjectName    string
-	WatchNamespace string
 }
 
 // Resource implements the secret resource.
@@ -38,7 +37,6 @@ type Resource struct {
 	// Settings.
 	chartNamespace string
 	projectName    string
-	watchNamespace string
 }
 
 // New creates a new configured secret resource.
@@ -67,7 +65,6 @@ func New(config Config) (*Resource, error) {
 
 		chartNamespace: config.ChartNamespace,
 		projectName:    config.ProjectName,
-		watchNamespace: config.WatchNamespace,
 	}
 
 	return r, nil

--- a/service/controller/app/v1/resource/secret/update_test.go
+++ b/service/controller/app/v1/resource/secret/update_test.go
@@ -137,7 +137,6 @@ func Test_Resource_newUpdateChange(t *testing.T) {
 
 		ChartNamespace: "giantswarm",
 		ProjectName:    "app-operator",
-		WatchNamespace: "default",
 	}
 	r, err := New(c)
 	if err != nil {

--- a/service/controller/app/v1/resource_set.go
+++ b/service/controller/app/v1/resource_set.go
@@ -127,7 +127,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 
 			ChartNamespace: config.ChartNamespace,
 			ProjectName:    config.ProjectName,
-			WatchNamespace: config.WatchNamespace,
 		}
 
 		ops, err := configmap.New(c)
@@ -150,7 +149,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 
 			ChartNamespace: config.ChartNamespace,
 			ProjectName:    config.ProjectName,
-			WatchNamespace: config.WatchNamespace,
 		}
 
 		ops, err := secret.New(c)


### PR DESCRIPTION
Some resources do not need `watchNamespace` variable for their configs. 
So I'm removing from secret/configmap resource. 