### PR TITLE
Extract getting configmap data to values service

### DIFF
--- a/service/controller/app/v1/key/key.go
+++ b/service/controller/app/v1/key/key.go
@@ -62,21 +62,21 @@ func ChartSecretName(customResource v1alpha1.App) string {
 	return fmt.Sprintf("%s-chart-secrets", customResource.GetName())
 }
 
-func CordonReason(customObject v1alpha1.App) string {
-	return customObject.GetAnnotations()[annotation.CordonReason]
+func CordonReason(customResource v1alpha1.App) string {
+	return customResource.GetAnnotations()[annotation.CordonReason]
 }
 
-func CordonUntil(customObject v1alpha1.App) string {
-	return customObject.GetAnnotations()[annotation.CordonUntil]
+func CordonUntil(customResource v1alpha1.App) string {
+	return customResource.GetAnnotations()[annotation.CordonUntil]
 }
 
 func InCluster(customResource v1alpha1.App) bool {
 	return customResource.Spec.KubeConfig.InCluster
 }
 
-func IsCordoned(customObject v1alpha1.App) bool {
-	_, reasonOk := customObject.Annotations[annotation.CordonReason]
-	_, untilOk := customObject.Annotations[annotation.CordonUntil]
+func IsCordoned(customResource v1alpha1.App) bool {
+	_, reasonOk := customResource.Annotations[annotation.CordonReason]
+	_, untilOk := customResource.Annotations[annotation.CordonUntil]
 
 	if reasonOk && untilOk {
 		return true

--- a/service/controller/app/v1/values/configmap.go
+++ b/service/controller/app/v1/values/configmap.go
@@ -13,7 +13,18 @@ import (
 	appcatalogkey "github.com/giantswarm/app-operator/service/controller/appcatalog/v1/key"
 )
 
+// MergeConfigMapData merges the data from the catalog, app and user configmaps
+// and returns a single set of values.
 func (v *Values) MergeConfigMapData(ctx context.Context, app v1alpha1.App, appCatalog v1alpha1.AppCatalog) (map[string]string, error) {
+	appConfigMapName := key.AppConfigMapName(app)
+	catalogConfigMapName := appcatalogkey.ConfigMapName(appCatalog)
+	userConfigMapName := key.UserConfigMapName(app)
+
+	if appConfigMapName == "" && catalogConfigMapName == "" && userConfigMapName == "" {
+		// Return early as there is no config.
+		return nil, nil
+	}
+
 	// We get the catalog level values if configured.
 	catalogData, err := v.getConfigMapForCatalog(ctx, appCatalog)
 	if err != nil {

--- a/service/controller/app/v1/values/configmap.go
+++ b/service/controller/app/v1/values/configmap.go
@@ -1,0 +1,110 @@
+package values
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/app-operator/service/controller/app/v1/key"
+	appcatalogkey "github.com/giantswarm/app-operator/service/controller/appcatalog/v1/key"
+)
+
+func (v *Values) MergeConfigMapData(ctx context.Context, app v1alpha1.App, appCatalog v1alpha1.AppCatalog) (map[string]string, error) {
+	// We get the catalog level values if configured.
+	catalogData, err := v.getConfigMapForCatalog(ctx, appCatalog)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// We get the app level values if configured.
+	appData, err := v.getConfigMapForApp(ctx, app)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// Config is merged and in case of intersecting values the app level
+	// config is preferred.
+	mergedData, err := mergeConfigMapData(catalogData, appData)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// We get the user level values if configured and merge them.
+	if key.UserConfigMapName(app) != "" {
+		userData, err := v.getUserConfigMapForApp(ctx, app)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		// Config is merged again and in case of intersecting values the user
+		// level config is preferred.
+		mergedData, err = mergeConfigMapData(mergedData, userData)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return mergedData, nil
+}
+
+func (v *Values) getConfigMap(ctx context.Context, configMapName, configMapNamespace string) (map[string]string, error) {
+	if configMapName == "" {
+		// Return early as no configmap has been specified.
+		return nil, nil
+	}
+
+	v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("looking for configmap %#q in namespace %#q", configMapName, configMapNamespace))
+
+	configMap, err := v.k8sClient.CoreV1().ConfigMaps(configMapNamespace).Get(configMapName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, microerror.Maskf(notFoundError, "configmap %#q in namespace %#q not found", configMapName, configMapNamespace)
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found configmap %#q in namespace %#q", configMapName, configMapNamespace))
+
+	return configMap.Data, nil
+}
+
+func (v *Values) getConfigMapForApp(ctx context.Context, app v1alpha1.App) (map[string]string, error) {
+	configMap, err := v.getConfigMap(ctx, key.AppConfigMapName(app), key.AppConfigMapNamespace(app))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return configMap, nil
+}
+
+func (v *Values) getConfigMapForCatalog(ctx context.Context, catalog v1alpha1.AppCatalog) (map[string]string, error) {
+	configMap, err := v.getConfigMap(ctx, appcatalogkey.ConfigMapName(catalog), appcatalogkey.ConfigMapNamespace(catalog))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return configMap, nil
+}
+
+func (v *Values) getUserConfigMapForApp(ctx context.Context, app v1alpha1.App) (map[string]string, error) {
+	configMap, err := v.getConfigMap(ctx, key.UserConfigMapName(app), key.UserConfigMapNamespace(app))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return configMap, nil
+}
+
+// mergeConfigMapData merges configmap data into a single block of YAML that
+// is stored in the configmap associated with the relevant chart CR.
+func mergeConfigMapData(destMap, srcMap map[string]string) (map[string]string, error) {
+	result, err := mergeData(toByteSliceMap(destMap), toByteSliceMap(srcMap))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return toStringMap(result), nil
+}

--- a/service/controller/app/v1/values/configmap_test.go
+++ b/service/controller/app/v1/values/configmap_test.go
@@ -1,0 +1,358 @@
+package values
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_MergeConfigMapData(t *testing.T) {
+	tests := []struct {
+		name         string
+		app          v1alpha1.App
+		appCatalog   v1alpha1.AppCatalog
+		configMaps   []*corev1.ConfigMap
+		expectedData map[string]string
+		errorMatcher func(error) bool
+	}{
+		{
+			name: "case 0: configmap is nil when there is no config",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "app-catalog",
+					Name:      "test-app",
+					Namespace: "kube-system",
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+			},
+			expectedData: nil,
+		},
+		{
+			name: "case 1: basic match with app config",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-prometheus",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "app-catalog",
+					Name:      "prometheus",
+					Namespace: "monitoring",
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "test-cluster-values",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+			},
+			configMaps: []*corev1.ConfigMap{
+				{
+					Data: map[string]string{
+						"values": "cluster: yaml\n",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster-values",
+						Namespace: "giantswarm",
+					},
+				},
+			},
+			expectedData: map[string]string{
+				"values": "cluster: yaml\n",
+			},
+		},
+		{
+			name: "case 2: basic match with catalog config",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "test-catalog",
+					Name:      "test-app",
+					Namespace: "giantswarm",
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+				Spec: v1alpha1.AppCatalogSpec{
+					Title: "test-catalog",
+					Config: v1alpha1.AppCatalogSpecConfig{
+						ConfigMap: v1alpha1.AppCatalogSpecConfigConfigMap{
+							Name:      "test-catalog-values",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			configMaps: []*corev1.ConfigMap{
+				{
+					Data: map[string]string{
+						"values": "catalog: yaml\n",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-catalog-values",
+						Namespace: "giantswarm",
+					},
+				},
+			},
+			expectedData: map[string]string{
+				"values": "catalog: yaml\n",
+			},
+		},
+		{
+			name: "case 3: non-intersecting catalog and app config are merged",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Name:      "test-app",
+					Namespace: "giantswarm",
+					Catalog:   "test-catalog",
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "test-cluster-values",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+				Spec: v1alpha1.AppCatalogSpec{
+					Title: "test-catalog",
+					Config: v1alpha1.AppCatalogSpecConfig{
+						ConfigMap: v1alpha1.AppCatalogSpecConfigConfigMap{
+							Name:      "test-catalog-values",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			configMaps: []*corev1.ConfigMap{
+				{
+					Data: map[string]string{
+						"values": "catalog: yaml\n",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-catalog-values",
+						Namespace: "giantswarm",
+					},
+				},
+				{
+					Data: map[string]string{
+						"values": "cluster: yaml\n",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster-values",
+						Namespace: "giantswarm",
+					},
+				},
+			},
+			expectedData: map[string]string{
+				"values": "catalog: yaml\ncluster: yaml\n",
+			},
+		},
+		{
+			name: "case 4: intersecting catalog and app config are merged, app is preferred",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Name:      "test-app",
+					Namespace: "giantswarm",
+					Catalog:   "test-catalog",
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "test-cluster-values",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+				Spec: v1alpha1.AppCatalogSpec{
+					Title: "test-catalog",
+					Config: v1alpha1.AppCatalogSpecConfig{
+						ConfigMap: v1alpha1.AppCatalogSpecConfigConfigMap{
+							Name:      "test-catalog-values",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			configMaps: []*corev1.ConfigMap{
+				{
+					Data: map[string]string{
+						"values": "test: catalog\n",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-catalog-values",
+						Namespace: "giantswarm",
+					},
+				},
+				{
+					Data: map[string]string{
+						"values": "test: app\n",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster-values",
+						Namespace: "giantswarm",
+					},
+				},
+			},
+			expectedData: map[string]string{
+				"values": "test: app\n",
+			},
+		},
+		{
+			name: "case 5: intersecting catalog, app and user config is merged, user is preferred",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Name:      "test-app",
+					Namespace: "giantswarm",
+					Catalog:   "test-catalog",
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "test-cluster-values",
+							Namespace: "giantswarm",
+						},
+					},
+					UserConfig: v1alpha1.AppSpecUserConfig{
+						ConfigMap: v1alpha1.AppSpecUserConfigConfigMap{
+							Name:      "test-user-values",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+				Spec: v1alpha1.AppCatalogSpec{
+					Title: "test-catalog",
+					Config: v1alpha1.AppCatalogSpecConfig{
+						ConfigMap: v1alpha1.AppCatalogSpecConfigConfigMap{
+							Name:      "test-catalog-values",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			configMaps: []*corev1.ConfigMap{
+				{
+					Data: map[string]string{
+						"values": "catalog: test\ntest: catalog\n",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-catalog-values",
+						Namespace: "giantswarm",
+					},
+				},
+				{
+					Data: map[string]string{
+						"values": "cluster: test\ntest: app\n",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster-values",
+						Namespace: "giantswarm",
+					},
+				},
+				{
+					Data: map[string]string{
+						"values": "user: test\ntest: user\n",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-user-values",
+						Namespace: "giantswarm",
+					},
+				},
+			},
+			expectedData: map[string]string{
+				"values": "catalog: test\ncluster: test\ntest: user\nuser: test\n",
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			objs := make([]runtime.Object, 0, 0)
+			for _, cm := range tc.configMaps {
+				objs = append(objs, cm)
+			}
+
+			c := Config{
+				K8sClient: clientgofake.NewSimpleClientset(objs...),
+				Logger:    microloggertest.New(),
+			}
+			v, err := New(c)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			result, err := v.MergeConfigMapData(ctx, tc.app, tc.appCatalog)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if result != nil && tc.expectedData == nil {
+				t.Fatalf("expected nil map got %#v", result)
+			}
+			if result == nil && tc.expectedData != nil {
+				t.Fatal("expected non-nil gmap got nil")
+			}
+
+			if tc.expectedData != nil {
+				if !reflect.DeepEqual(result, tc.expectedData) {
+					t.Fatalf("want matching data \n %s", cmp.Diff(result, tc.expectedData))
+				}
+			}
+		})
+	}
+}

--- a/service/controller/app/v1/values/error.go
+++ b/service/controller/app/v1/values/error.go
@@ -1,0 +1,21 @@
+package values
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/controller/app/v1/values/values.go
+++ b/service/controller/app/v1/values/values.go
@@ -3,8 +3,42 @@ package values
 import (
 	"github.com/giantswarm/helmclient"
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
 	yaml "gopkg.in/yaml.v2"
+	"k8s.io/client-go/kubernetes"
 )
+
+// Config represents the configuration used to create a new values service.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Values implements the values service.
+type Values struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured values service.
+func New(config Config) (*Values, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Values{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
 
 // MergeConfigMapData merges configmap data into a single block of YAML that
 // is stored in the configmap associated with the relevant chart CR.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6639

This is prep for extending app-operator to bootstrap chart-operator.

We need to provide values when installing chart-operator. So this moves the logic from the configmap resource to the values service. This will be used in the next PR.