### PR TITLE
Move MergeSecretData to values service

### DIFF
--- a/service/controller/app/v1/values/secret.go
+++ b/service/controller/app/v1/values/secret.go
@@ -1,0 +1,121 @@
+package values
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/app-operator/service/controller/app/v1/key"
+	appcatalogkey "github.com/giantswarm/app-operator/service/controller/appcatalog/v1/key"
+)
+
+// MergeSecretData merges the data from the catalog, app and user secretss
+// and returns a single set of values.
+func (v *Values) MergeSecretData(ctx context.Context, app v1alpha1.App, appCatalog v1alpha1.AppCatalog) (map[string][]byte, error) {
+	appSecretName := key.AppSecretName(app)
+	catalogSecretName := appcatalogkey.SecretName(appCatalog)
+	userSecretName := key.UserSecretName(app)
+
+	if appSecretName == "" && catalogSecretName == "" && userSecretName == "" {
+		// Return early as there is no secret.
+		return nil, nil
+	}
+
+	// We get the catalog level secrets if configured.
+	catalogData, err := v.getSecretDataForCatalog(ctx, appCatalog)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// We get the app level secrets if configured.
+	appData, err := v.getSecretDataForApp(ctx, app)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// Secrets are merged and in case of intersecting values the app level
+	// secrets are preferred.
+	mergedData, err := mergeSecretData(catalogData, appData)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// We get the user level values if configured and merge them.
+	if userSecretName != "" {
+		userData, err := v.getUserSecretDataForApp(ctx, app)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		// Secrets are merged again and in case of intersecting values the user
+		// level secrets are preferred.
+		mergedData, err = mergeSecretData(mergedData, userData)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return mergedData, nil
+}
+
+func (v *Values) getSecret(ctx context.Context, secretName, secretNamespace string) (map[string][]byte, error) {
+	if secretName == "" {
+		// Return early as no secret has been specified.
+		return nil, nil
+	}
+
+	v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("looking for secret %#q in namespace %#q", secretName, secretNamespace))
+
+	secret, err := v.k8sClient.CoreV1().Secrets(secretNamespace).Get(secretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, microerror.Maskf(notFoundError, "secret %#q in namespace %#q not found", secretName, secretNamespace)
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	v.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found secret %#q in namespace %#q", secretName, secretNamespace))
+
+	return secret.Data, nil
+}
+
+func (v *Values) getSecretDataForApp(ctx context.Context, app v1alpha1.App) (map[string][]byte, error) {
+	secret, err := v.getSecret(ctx, key.AppSecretName(app), key.AppSecretNamespace(app))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return secret, nil
+}
+
+func (v *Values) getSecretDataForCatalog(ctx context.Context, catalog v1alpha1.AppCatalog) (map[string][]byte, error) {
+	secret, err := v.getSecret(ctx, appcatalogkey.SecretName(catalog), appcatalogkey.SecretNamespace(catalog))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return secret, nil
+}
+
+func (v *Values) getUserSecretDataForApp(ctx context.Context, app v1alpha1.App) (map[string][]byte, error) {
+	secret, err := v.getSecret(ctx, key.UserSecretName(app), key.UserSecretNamespace(app))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return secret, nil
+}
+
+// mergeSecretData merges secret data into a single block of YAML that
+// is stored in the secret associated with the relevant chart CR.
+func mergeSecretData(destMap, srcMap map[string][]byte) (map[string][]byte, error) {
+	result, err := mergeData(destMap, srcMap)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return result, nil
+}

--- a/service/controller/app/v1/values/secret_test.go
+++ b/service/controller/app/v1/values/secret_test.go
@@ -1,0 +1,362 @@
+package values
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_MergeSecretData(t *testing.T) {
+	tests := []struct {
+		name         string
+		app          v1alpha1.App
+		appCatalog   v1alpha1.AppCatalog
+		secrets      []*corev1.Secret
+		expectedData map[string][]byte
+		errorMatcher func(error) bool
+	}{
+		{
+			name: "case 0: secret is nil when there are no secrets",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "app-catalog",
+					Name:      "test-app",
+					Namespace: "kube-system",
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+			},
+			expectedData: nil,
+		},
+		{
+			name: "case 1: basic match with app secrets",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-prometheus",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "app-catalog",
+					Name:      "prometheus",
+					Namespace: "monitoring",
+					Config: v1alpha1.AppSpecConfig{
+						Secret: v1alpha1.AppSpecConfigSecret{
+							Name:      "test-cluster-secrets",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+			},
+			secrets: []*corev1.Secret{
+				{
+					Data: map[string][]byte{
+						"secrets": []byte("cluster: yaml\n"),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster-secrets",
+						Namespace: "giantswarm",
+					},
+				},
+			},
+			expectedData: map[string][]byte{
+				"values": []byte("cluster: yaml\n"),
+			},
+		},
+		{
+			name: "case 2: basic match with catalog secrets",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "test-catalog",
+					Name:      "test-app",
+					Namespace: "giantswarm",
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+				Spec: v1alpha1.AppCatalogSpec{
+					Title: "test-catalog",
+					Config: v1alpha1.AppCatalogSpecConfig{
+						Secret: v1alpha1.AppCatalogSpecConfigSecret{
+							Name:      "test-catalog-secrets",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			secrets: []*corev1.Secret{
+				{
+					Data: map[string][]byte{
+						"secrets": []byte("catalog: yaml\n"),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-catalog-secrets",
+						Namespace: "giantswarm",
+					},
+				},
+			},
+			expectedData: map[string][]byte{
+				"values": []byte("catalog: yaml\n"),
+			},
+		},
+		{
+			name: "case 3: non-intersecting catalog and app secrets are merged",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog: "test-catalog",
+					Config: v1alpha1.AppSpecConfig{
+						Secret: v1alpha1.AppSpecConfigSecret{
+							Name:      "test-cluster-secrets",
+							Namespace: "giantswarm",
+						},
+					},
+					Name:      "test-app",
+					Namespace: "giantswarm",
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+				Spec: v1alpha1.AppCatalogSpec{
+					Title: "test-catalog",
+					Config: v1alpha1.AppCatalogSpecConfig{
+						Secret: v1alpha1.AppCatalogSpecConfigSecret{
+							Name:      "test-catalog-secrets",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			secrets: []*corev1.Secret{
+				{
+					Data: map[string][]byte{
+						"values": []byte("catalog: yaml\n"),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-catalog-secrets",
+						Namespace: "giantswarm",
+					},
+				},
+				{
+					Data: map[string][]byte{
+						"values": []byte("cluster: yaml\n"),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster-secrets",
+						Namespace: "giantswarm",
+					},
+				},
+			},
+			expectedData: map[string][]byte{
+				"values": []byte("catalog: yaml\ncluster: yaml\n"),
+			},
+		},
+		{
+			name: "case 4: intersecting catalog and app secrets, app overwrites catalog",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog: "test-catalog",
+					Config: v1alpha1.AppSpecConfig{
+						Secret: v1alpha1.AppSpecConfigSecret{
+							Name:      "test-cluster-secrets",
+							Namespace: "giantswarm",
+						},
+					},
+					Name:      "test-app",
+					Namespace: "giantswarm",
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+				Spec: v1alpha1.AppCatalogSpec{
+					Title: "test-catalog",
+					Config: v1alpha1.AppCatalogSpecConfig{
+						Secret: v1alpha1.AppCatalogSpecConfigSecret{
+							Name:      "test-catalog-secrets",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			secrets: []*corev1.Secret{
+				{
+					Data: map[string][]byte{
+						"values": []byte("catalog: yaml\ntest: catalog\n"),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-catalog-secrets",
+						Namespace: "giantswarm",
+					},
+				},
+				{
+					Data: map[string][]byte{
+						"values": []byte("cluster: yaml\ntest: app\n"),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster-secrets",
+						Namespace: "giantswarm",
+					},
+				},
+			},
+			expectedData: map[string][]byte{
+				// "test: app" overrides "test: catalog".
+				"values": []byte("catalog: yaml\ncluster: yaml\ntest: app\n"),
+			},
+		},
+		{
+			name: "case 5: intersecting catalog, app and user secrets are merged, user is preferred",
+			app: v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog: "test-catalog",
+					Config: v1alpha1.AppSpecConfig{
+						Secret: v1alpha1.AppSpecConfigSecret{
+							Name:      "test-cluster-secrets",
+							Namespace: "giantswarm",
+						},
+					},
+					Name:      "test-app",
+					Namespace: "giantswarm",
+					UserConfig: v1alpha1.AppSpecUserConfig{
+						Secret: v1alpha1.AppSpecUserConfigSecret{
+							Name:      "test-user-secrets",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-catalog",
+				},
+				Spec: v1alpha1.AppCatalogSpec{
+					Title: "test-catalog",
+					Config: v1alpha1.AppCatalogSpecConfig{
+						Secret: v1alpha1.AppCatalogSpecConfigSecret{
+							Name:      "test-catalog-secrets",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			secrets: []*corev1.Secret{
+				{
+					Data: map[string][]byte{
+						"values": []byte("catalog: test\ntest: catalog\n"),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-catalog-secrets",
+						Namespace: "giantswarm",
+					},
+				},
+				{
+					Data: map[string][]byte{
+						"values": []byte("cluster: test\ntest: app\n"),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster-secrets",
+						Namespace: "giantswarm",
+					},
+				},
+				{
+					Data: map[string][]byte{
+						"values": []byte("user: test\ntest: user\n"),
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-user-secrets",
+						Namespace: "giantswarm",
+					},
+				},
+			},
+			expectedData: map[string][]byte{
+				// "test: user" overrides "test: catalog" and "test: app".
+				"values": []byte("catalog: test\ncluster: test\ntest: user\nuser: test\n"),
+			},
+		},
+	}
+	ctx := context.Background()
+
+	for i, tc := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			objs := make([]runtime.Object, 0, 0)
+			for _, cm := range tc.secrets {
+				objs = append(objs, cm)
+			}
+
+			c := Config{
+				K8sClient: clientgofake.NewSimpleClientset(objs...),
+				Logger:    microloggertest.New(),
+			}
+			v, err := New(c)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			result, err := v.MergeSecretData(ctx, tc.app, tc.appCatalog)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if result != nil && tc.expectedData == nil {
+				t.Fatalf("expected nil secret got %#v", result)
+			}
+			if result == nil && tc.expectedData != nil {
+				t.Fatal("expected non-nil secret got nil")
+			}
+
+			if tc.expectedData != nil {
+				if !reflect.DeepEqual(result, tc.expectedData) {
+					data := toStringMap(result)
+					expectedData := toStringMap(tc.expectedData)
+
+					t.Fatalf("want matching data \n %s", cmp.Diff(data, expectedData))
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#6639

Same deal as for configmaps. This first PR extracts the secret merge logic to the values service. The next PR will use it.