### PR TITLE
Don't set annotations in chart resource

### DIFF
--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"strings"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/app-operator/pkg/annotation"
 	"github.com/giantswarm/app-operator/pkg/label"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/key"
@@ -41,10 +39,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			APIVersion: chartAPIVersion,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: processAnnotations(cr),
-			Name:        cr.GetName(),
-			Namespace:   r.chartNamespace,
-			Labels:      processLabels(r.projectName, cr.GetLabels()),
+			Name:      cr.GetName(),
+			Namespace: r.chartNamespace,
+			Labels:    processLabels(r.projectName, cr.GetLabels()),
 		},
 		Spec: v1alpha1.ChartSpec{
 			Config:     config,
@@ -107,30 +104,6 @@ func hasSecret(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog) bool {
 	}
 
 	return false
-}
-
-func replacePrefix(from string) string {
-	return strings.Replace(from, "app-operator.giantswarm.io", "chart-operator.giantswarm.io", 1)
-}
-
-// processAnnotations ensures necessary app-operator.giantswarm.io annotations
-// are copied into the proper prefix in chart CR.
-func processAnnotations(cr v1alpha1.App) map[string]string {
-	if cr.GetAnnotations() == nil {
-		return nil
-	}
-
-	newAnnotations := map[string]string{}
-
-	if key.IsCordoned(cr) {
-		cordonReasonKey := replacePrefix(annotation.CordonReason)
-		newAnnotations[cordonReasonKey] = key.CordonReason(cr)
-
-		cordonUntilKey := replacePrefix(annotation.CordonUntil)
-		newAnnotations[cordonUntilKey] = key.CordonUntil(cr)
-	}
-
-	return newAnnotations
 }
 
 // processLabels ensures the chart-operator.giantswarm.io/version label is

--- a/service/controller/app/v1/resource/chart/desired_test.go
+++ b/service/controller/app/v1/resource/chart/desired_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/app-operator/pkg/annotation"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
 )
 
@@ -149,90 +148,6 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				},
 			},
 			errorMatcher: IsExecutionFailed,
-		},
-		{
-			name: "case 2: cordoned app",
-			obj: &v1alpha1.App{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						annotation.CordonReason: "migrating job in process",
-						annotation.CordonUntil:  "2019-12-31T23:59:59Z",
-					},
-					Name:      "my-cool-prometheus",
-					Namespace: "default",
-					Labels: map[string]string{
-						"app":                                "prometheus",
-						"app-operator.giantswarm.io/version": "1.0.0",
-						"giantswarm.io/managed-by":           "cluster-operator",
-					},
-				},
-				Spec: v1alpha1.AppSpec{
-					Catalog:   "giantswarm",
-					Name:      "kubernetes-prometheus",
-					Namespace: "monitoring",
-					Version:   "1.0.0",
-					Config: v1alpha1.AppSpecConfig{
-						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
-							Name:      "giant-swarm-config",
-							Namespace: "giantswarm",
-						},
-					},
-					KubeConfig: v1alpha1.AppSpecKubeConfig{
-						Secret: v1alpha1.AppSpecKubeConfigSecret{
-							Name:      "giantswarm-12345",
-							Namespace: "12345",
-						},
-					},
-				},
-			},
-			appCatalog: v1alpha1.AppCatalog{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "giantswarm",
-					Namespace: "default",
-					Labels: map[string]string{
-						"app-operator.giantswarm.io/version": "1.0.0",
-					},
-				},
-				Spec: v1alpha1.AppCatalogSpec{
-					Title:       "Giant Swarm",
-					Description: "Catalog of Apps by Giant Swarm",
-					Storage: v1alpha1.AppCatalogSpecStorage{
-						Type: "helm",
-						URL:  "https://giantswarm.github.com/app-catalog/",
-					},
-					LogoURL: "https://s.giantswarm.io/...",
-				},
-			},
-			expectedChart: &v1alpha1.Chart{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Chart",
-					APIVersion: "application.giantswarm.io",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"chart-operator.giantswarm.io/cordon-reason": "migrating job in process",
-						"chart-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
-					},
-					Name:      "my-cool-prometheus",
-					Namespace: "giantswarm",
-					Labels: map[string]string{
-						"app":                                  "prometheus",
-						"chart-operator.giantswarm.io/version": "1.0.0",
-						"giantswarm.io/managed-by":             "app-operator",
-					},
-				},
-				Spec: v1alpha1.ChartSpec{
-					Config: v1alpha1.ChartSpecConfig{
-						ConfigMap: v1alpha1.ChartSpecConfigConfigMap{
-							Name:      "my-cool-prometheus-chart-values",
-							Namespace: "giantswarm",
-						},
-					},
-					Name:       "my-cool-prometheus",
-					Namespace:  "monitoring",
-					TarballURL: "https://giantswarm.github.com/app-catalog/kubernetes-prometheus-1.0.0.tgz",
-				},
-			},
 		},
 	}
 
@@ -540,60 +455,6 @@ func Test_processLabels(t *testing.T) {
 
 			if !reflect.DeepEqual(result, tc.expectedLabels) {
 				t.Fatalf("want matching \n %s", cmp.Diff(result, tc.expectedLabels))
-			}
-		})
-	}
-}
-
-func Test_processAnnotations(t *testing.T) {
-	tests := []struct {
-		name                string
-		obj                 *v1alpha1.App
-		expectedAnnotations map[string]string
-	}{
-		{
-			name: "case 0: basic match",
-			obj: &v1alpha1.App{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Chart",
-					APIVersion: "application.giantswarm.io",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"app-operator.giantswarm.io/cordon-reason": "migrating job in process",
-						"app-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
-					},
-				},
-			},
-			expectedAnnotations: map[string]string{
-				"chart-operator.giantswarm.io/cordon-reason": "migrating job in process",
-				"chart-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
-			},
-		},
-		{
-			name: "case 1: filter other annotations",
-			obj: &v1alpha1.App{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Chart",
-					APIVersion: "application.giantswarm.io",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"kubectl.kubernetes.io/last-applied-configuration": "application.giantswarm.io/v1alpha1",
-					},
-				},
-			},
-			expectedAnnotations: map[string]string{},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-
-			result := processAnnotations(*tc.obj)
-
-			if !reflect.DeepEqual(result, tc.expectedAnnotations) {
-				t.Fatalf("want matching \n %s", cmp.Diff(result, tc.expectedAnnotations))
 			}
 		})
 	}

--- a/service/controller/app/v1/resource/chart/resource.go
+++ b/service/controller/app/v1/resource/chart/resource.go
@@ -86,16 +86,6 @@ func equals(current, desired *v1alpha1.Chart) bool {
 		return false
 	}
 
-	desiredAnnotations := desired.GetAnnotations()
-	for currentKey, currentValue := range current.GetAnnotations() {
-		if desiredValue, ok := desiredAnnotations[currentKey]; ok {
-			if currentValue != desiredValue {
-				return false
-			}
-		} else {
-			return false
-		}
-	}
 	return true
 }
 

--- a/service/controller/app/v1/resource/chart/update_test.go
+++ b/service/controller/app/v1/resource/chart/update_test.go
@@ -76,47 +76,6 @@ func Test_Resource_newUpdateChange(t *testing.T) {
 			},
 			expectedChart: &v1alpha1.Chart{},
 		},
-		{
-			name: "case 2: chart should be updated for cordon annotations",
-			currentResource: &v1alpha1.Chart{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"chart-operator.giantswarm.io/values-md5-checksum": "52668444a530c7b296f9c620f8cb2632",
-					},
-					Name: "prometheus",
-				},
-				Spec: v1alpha1.ChartSpec{
-					Name:      "my-cool-prometheus",
-					Namespace: "monitoring",
-				},
-			},
-			desiredResource: &v1alpha1.Chart{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"chart-operator.giantswarm.io/cordon-reason": "chart maintenance",
-						"chart-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
-					},
-					Name: "prometheus",
-				},
-				Spec: v1alpha1.ChartSpec{
-					Name:      "my-cool-prometheus",
-					Namespace: "monitoring",
-				},
-			},
-			expectedChart: &v1alpha1.Chart{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"chart-operator.giantswarm.io/cordon-reason": "chart maintenance",
-						"chart-operator.giantswarm.io/cordon-until":  "2019-12-31T23:59:59Z",
-					},
-					Name: "prometheus",
-				},
-				Spec: v1alpha1.ChartSpec{
-					Name:      "my-cool-prometheus",
-					Namespace: "monitoring",
-				},
-			},
-		},
 	}
 
 	c := Config{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6696

Removes setting cordon annotations for chart CRs. Logic will be moved to a new `cordonchart` resource.

See https://github.com/giantswarm/giantswarm/issues/6696#issuecomment-520219595. 