### PR TITLE
Disable chart-operator resource

### DIFF
--- a/service/controller/app/v1/resource_set.go
+++ b/service/controller/app/v1/resource_set.go
@@ -17,7 +17,6 @@ import (
 	"github.com/giantswarm/app-operator/service/controller/app/v1/resource/appcatalog"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/resource/appnamespace"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/resource/chart"
-	"github.com/giantswarm/app-operator/service/controller/app/v1/resource/chartoperator"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/resource/clients"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/resource/configmap"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/resource/secret"
@@ -103,6 +102,8 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
+	/* Disable while issues with InCluster are fixed.
+
 	var chartOperatorResource controller.Resource
 	{
 		c := chartoperator.Config{
@@ -116,6 +117,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			return nil, microerror.Mask(err)
 		}
 	}
+	*/
 
 	var chartResource controller.Resource
 	{
@@ -213,7 +215,8 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		appNamespaceResource,
 		appcatalogResource,
 		clientsResource,
-		chartOperatorResource,
+		// Disable while issues with InCluster are fixed.
+		//chartOperatorResource,
 		configMapResource,
 		secretResource,
 		chartResource,


### PR DESCRIPTION
Fixes a problem found by @TheoBrigitte in `ginger` with app CRs using InCluster. Disabling until we can fix this.