### PR TITLE
Add status perms for appcatalog CRD

### DIFF
--- a/helm/app-operator-chart/templates/rbac.yaml
+++ b/helm/app-operator-chart/templates/rbac.yaml
@@ -39,6 +39,14 @@ rules:
     - patch
     - watch
 - apiGroups:
+    - application.giantswarm.io
+  resources:
+    - appcatalogs/status
+  verbs:
+    - create
+    - patch
+    - update
+- apiGroups:
   - "rbac.authorization.k8s.io"
   resources:
   - clusterrolebindings


### PR DESCRIPTION
The status subresource got added to the appcatalog CRD but the cluster role didn't get updated.


```
W 09/03 14:49:51 retrying backoff in '1s' due to error | backoff/notifier.go:13 | controller=app-operator
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:143:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:381:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/client/k8scrdclient/k8scrdclient.go:85:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/client/k8scrdclient/k8scrdclient.go:140:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/client/k8scrdclient/k8scrdclient.go:131:
	customresourcedefinitions.apiextensions.k8s.io "appcatalogs.application.giantswarm.io" is forbidden: User "system:serviceaccount:giantswarm:app-operator" cannot update resource "customresourcedefinitions/status" in API group "apiextensions.k8s.io" at the cluster scope
```