### PR TITLE
Check app CR status in e2e

### DIFF
--- a/integration/test/app/basic/simple_test.go
+++ b/integration/test/app/basic/simple_test.go
@@ -236,6 +236,20 @@ func TestAppLifecycle(t *testing.T) {
 	}
 
 	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checking status for app CR %#q", key.TestAppReleaseName()))
+
+		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps("giantswarm").Get(key.TestAppReleaseName(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+		if cr.Status.Release.Status != "DEPLOYED" {
+			t.Fatalf("expected CR release status %#q got %#q", "DEPLOYED", cr.Status.Release.Status)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("checked status for app CR %#q", key.TestAppReleaseName()))
+	}
+
+	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting release %#q", key.CustomResourceReleaseName()))
 
 		err := config.Release.Delete(ctx, key.CustomResourceReleaseName())


### PR DESCRIPTION
This got removed when I needed to revert the CRD changes in https://github.com/giantswarm/app-operator/pull/135. Gets it back in so we have coverage for the status resource.

