### PR TITLE
Use values service in chart-operator resource

### DIFF
--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -5,11 +5,8 @@ package templates
 // ChartOperatorValues values required by chart-operator-chart.
 const ChartOperatorValues = `
 clusterDNSIP: 10.96.0.10
-<<<<<<< HEAD
-=======
 image:
   registry: "quay.io"
->>>>>>> master
 tiller:
   namespace: "giantswarm"
 `

--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -5,6 +5,7 @@ package templates
 // ChartOperatorValues values required by chart-operator-chart.
 const ChartOperatorValues = `
 clusterDNSIP: 10.96.0.10
+e2e: true
 externalDNSIP: 8.8.8.8
 image:
   registry: "quay.io"

--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -5,6 +5,7 @@ package templates
 // ChartOperatorValues values required by chart-operator-chart.
 const ChartOperatorValues = `
 clusterDNSIP: 10.96.0.10
+externalDNSIP: 8.8.8.8
 image:
   registry: "quay.io"
 tiller:

--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -5,7 +5,6 @@ package templates
 // ChartOperatorValues values required by chart-operator-chart.
 const ChartOperatorValues = `
 clusterDNSIP: 10.96.0.10
-resource:
-  tiller:
-    namespace: "giantswarm"
+tiller:
+  namespace: "giantswarm"
 `

--- a/integration/test/app/kubeconfig/kubeconfig_test.go
+++ b/integration/test/app/kubeconfig/kubeconfig_test.go
@@ -155,7 +155,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 				},
 				Name:      "chart-operator",
 				Namespace: "giantswarm",
-				Version:   "0.10.2",
+				Version:   "0.10.4",
 			},
 		})
 		if err != nil {

--- a/integration/test/app/kubeconfig/kubeconfig_test.go
+++ b/integration/test/app/kubeconfig/kubeconfig_test.go
@@ -137,7 +137,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 
 		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().AppCatalogs().Create(&v1alpha1.AppCatalog{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "default-test",
+				Name: "default",
 			},
 			Spec: v1alpha1.AppCatalogSpec{
 				Config: v1alpha1.AppCatalogSpecConfig{
@@ -148,7 +148,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 				},
 				Storage: v1alpha1.AppCatalogSpecStorage{
 					Type: "helm",
-					URL:  "https://giantswarm.github.com/default-test-catalog/",
+					URL:  "https://giantswarm.github.com/default-catalog/",
 				},
 				Title: "Giant Swarm Default Catalog",
 			},
@@ -166,7 +166,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 				},
 			},
 			Spec: v1alpha1.AppSpec{
-				Catalog: "default-test",
+				Catalog: "default",
 				KubeConfig: v1alpha1.AppSpecKubeConfig{
 					Secret: v1alpha1.AppSpecKubeConfigSecret{
 						Name:      "kube-config",
@@ -175,7 +175,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 				},
 				Name:      "chart-operator",
 				Namespace: "giantswarm",
-				Version:   "0.10.4-25fd6e0d6cd4c3b6e45edf69207282486a597f0f",
+				Version:   "0.10.5",
 			},
 		})
 		if err != nil {

--- a/service/controller/app/v1/resource/chartoperator/resource.go
+++ b/service/controller/app/v1/resource/chartoperator/resource.go
@@ -192,7 +192,7 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 		// Wait for chart-operator to be deployed. If it takes longer than
 		// the timeout the chartconfig CRs will be created during the next
 		// reconciliation loop.
-		b := backoff.NewConstant(30*time.Second, 5*time.Second)
+		b := backoff.NewConstant(20*time.Second, 10*time.Second)
 		n := func(err error, delay time.Duration) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q deployment is not ready retrying in %s", release, delay), "stack", fmt.Sprintf("%#v", err))
 		}

--- a/service/controller/app/v1/resource_set.go
+++ b/service/controller/app/v1/resource_set.go
@@ -113,6 +113,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			G8sClient:  config.G8sClient,
 			K8sClient:  config.K8sClient,
 			Logger:     config.Logger,
+			Values:     valuesService,
 		}
 		chartOperatorResource, err = chartoperator.New(c)
 		if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6874

On Azure and some onprem installations we can't use 8.8.8.8 for bootstrapping CoreDNS. This is not set in the default app catalog.

This is some refactoring to use the `values` package for generating the values used to install chart-operator. So we don't need to make code changes when we add new values.


