### PR TITLE
Update chart-operator tarball URL for basic e2e test

### DIFF
--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -5,7 +5,8 @@ package templates
 // ChartOperatorValues values required by chart-operator-chart.
 const ChartOperatorValues = `
 clusterDNSIP: 10.96.0.10
-resource:
-  tiller:
-    namespace: "giantswarm"
+image:
+  registry: "quay.io"
+tiller:
+  namespace: "giantswarm"
 `

--- a/integration/test/app/basic/simple_test.go
+++ b/integration/test/app/basic/simple_test.go
@@ -94,7 +94,7 @@ func TestAppLifecycle(t *testing.T) {
 			//
 			//	See https://github.com/giantswarm/giantswarm/issues/6824
 			//
-			tarballURL := "https://giantswarm.github.io/giantswarm-catalog/chart-operator-0.9.0.tgz"
+			tarballURL := "https://giantswarm.github.io/default-catalog/chart-operator-0.10.2.tgz"
 			tarballPath, err = config.HelmClient.PullChartTarball(ctx, tarballURL)
 			if err != nil {
 				t.Fatalf("expected %#v got %#v", nil, err)


### PR DESCRIPTION
At the moment we only use chart-operator bootstrapping for tenant clusters. So the tarball URL needs to be updated.

There is a TODO to also use the bootstrapping for VOO. The difference is for these app CRs the InCluster flag is true.