### PR TITLE
Use InstallWait in chartoperator resource

### DIFF
--- a/service/controller/app/v1/resource/chart/create.go
+++ b/service/controller/app/v1/resource/chart/create.go
@@ -52,6 +52,11 @@ func (r *Resource) newCreateChange(ctx context.Context, currentResource, desired
 
 	createChart := &v1alpha1.Chart{}
 
+	if desiredChart.Name == "chart-operator" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not creating %#q chart", desiredChart.Name))
+		return createChart, nil
+	}
+
 	if isEmpty(currentChart) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("the %#q chart needs to be created", desiredChart.Name))
 		createChart = desiredChart

--- a/service/controller/app/v1/resource/chart/update.go
+++ b/service/controller/app/v1/resource/chart/update.go
@@ -69,6 +69,12 @@ func (r *Resource) newUpdateChange(ctx context.Context, currentResource, desired
 	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the chart has to be updated")
 
 	updateChart := &v1alpha1.Chart{}
+
+	if desiredChart.Name == "chart-operator" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not creating %#q chart", desiredChart.Name))
+		return updateChart, nil
+	}
+
 	isModified := !isEmpty(currentChart) && !equals(currentChart, desiredChart)
 	if isModified {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "the chart has to be updated")

--- a/service/controller/app/v1/resource/chartoperator/resource.go
+++ b/service/controller/app/v1/resource/chartoperator/resource.go
@@ -189,7 +189,10 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 	}
 
 	{
-		err = cc.HelmClient.InstallReleaseFromTarball(ctx, tarballPath, namespace, helm.ReleaseName(release), helm.ValueOverrides(chartOperatorValue))
+		err = cc.HelmClient.InstallReleaseFromTarball(ctx, tarballPath, namespace,
+			helm.InstallWait(true),
+			helm.ReleaseName(release),
+			helm.ValueOverrides(chartOperatorValue))
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
In the chartoperator resource in cluster-operator we use `helm.InstallWait`. In app-operator we aren't using it.

It could be related to weird problems we're seeing with chart-operator bootstrapping. 