### PR TITLE
less aggressive to update chart-operator in TC 

### DIFF
--- a/service/controller/app/v1/resource/chartoperator/resource.go
+++ b/service/controller/app/v1/resource/chartoperator/resource.go
@@ -213,7 +213,7 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 		// Wait for chart-operator to be deployed. If it takes longer than
 		// the timeout the chartconfig CRs will be created during the next
 		// reconciliation loop.
-		b := backoff.NewConstant(30*time.Second, 5*time.Second)
+		b := backoff.NewConstant(20*time.Second, 10*time.Second)
 		n := func(err error, delay time.Duration) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q deployment is not ready retrying in %s", release, delay), "stack", fmt.Sprintf("%#v", err))
 		}

--- a/vendor/github.com/giantswarm/e2esetup/k8s/setup.go
+++ b/vendor/github.com/giantswarm/e2esetup/k8s/setup.go
@@ -1,4 +1,4 @@
-package k8s
+ackage k8s
 
 import (
 	"context"

--- a/vendor/github.com/giantswarm/e2esetup/k8s/setup.go
+++ b/vendor/github.com/giantswarm/e2esetup/k8s/setup.go
@@ -1,4 +1,4 @@
-ackage k8s
+package k8s
 
 import (
 	"context"


### PR DESCRIPTION

When app-operator failed to install chart-operator in TC, it retries 6 times for every reconciliation, all in 30 seconds. 

I think that's too much and chart update revision number is getting higher too fast. 

Below is the helm chart list just after 3 minutes after cluster creation.

```
helm --tiller-namespace giantswarm ls
NAME                    	REVISION	UPDATED                 	STATUS  	CHART                                                       	APP VERSION	NAMESPACE
cert-exporter           	2       	Thu Sep 26 11:49:54 2019	DEPLOYED	cert-exporter-chart-1.0.0-228632041f419d45c1aadf7a713a4b3...	           	kube-system
chart-operator          	128     	Thu Sep 26 12:23:40 2019	FAILED  	chart-operator-0.10.3                                       	           	giantswarm
cluster-autoscaler      	1       	Thu Sep 26 11:49:55 2019	DEPLOYED	kubernetes-cluster-autoscaler-chart-0.7.0-6dc276bb0756cf0...	           	kube-system
coredns                 	2       	Thu Sep 26 11:49:52 2019	DEPLOYED	kubernetes-coredns-chart-0.6.3-f4140493ae12b0773d68417acd...	1.5.1      	kube-system
kube-state-metrics      	2       	Thu Sep 26 11:50:01 2019	DEPLOYED	kubernetes-kube-state-metrics-chart-0.3.4-dd99152f5d80746...	v1.6.0     	kube-system
metrics-server          	2       	Thu Sep 26 11:50:06 2019	DEPLOYED	kubernetes-metrics-server-chart-0.3.0-41665a4b51308b4082a...	0.3.3      	kube-system
net-exporter            	2       	Thu Sep 26 11:50:10 2019	DEPLOYED	net-exporter-chart-1.0.0-9476dceada4f4577dd765fb8026d7d9a...	           	kube-system
nginx-ingress-controller	2       	Thu Sep 26 11:50:14 2019	DEPLOYED	kubernetes-nginx-ingress-controller-chart-0.9.1-ef1712861...	v0.25.1    	kube-system
node-exporter           	2       	Thu Sep 26 11:50:18 2019	DEPLOYED	kubernetes-node-exporter-chart-0.5.1-7cea31fb2f2db2c152d1...	v0.18.0    	kube-system
```

This change suggest to only try to look into chart-operator 2 times for 20 seconds. 