### PR TITLE
Use externalDNSIP in chartoperator resource

### DIFF
--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -5,6 +5,7 @@ package templates
 // ChartOperatorValues values required by chart-operator-chart.
 const ChartOperatorValues = `
 clusterDNSIP: 10.96.0.10
+externalDNSIP: 8.8.8.8
 image:
   registry: "quay.io"
 tiller:

--- a/integration/test/app/kubeconfig/kubeconfig_test.go
+++ b/integration/test/app/kubeconfig/kubeconfig_test.go
@@ -155,7 +155,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 				},
 				Name:      "chart-operator",
 				Namespace: "giantswarm",
-				Version:   "0.10.2",
+				Version:   "0.10.4",
 			},
 		})
 		if err != nil {

--- a/service/controller/app/v1/resource/chartoperator/resource.go
+++ b/service/controller/app/v1/resource/chartoperator/resource.go
@@ -149,6 +149,7 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 	}
 
 	var clusterDNSIP string
+	var externalDNSIP string
 	{
 		name := key.ClusterValuesConfigMapName(cr)
 		cm, err := r.k8sClient.CoreV1().ConfigMaps(cr.Namespace).Get(name, metav1.GetOptions{})
@@ -164,6 +165,7 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 			}
 
 			clusterDNSIP = values["clusterDNSIP"]
+			externalDNSIP = values["externalDNSIP"]
 		}
 	}
 
@@ -180,6 +182,9 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 
 		if clusterDNSIP != "" {
 			v["clusterDNSIP"] = clusterDNSIP
+		}
+		if externalDNSIP != "" {
+			v["externalDNSIP"] = externalDNSIP
 		}
 
 		chartOperatorValue, err = json.Marshal(v)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6874

We use `8.8.8.8` for DNS to bootstrap CoreDNS in new tenant clusters. But on Azure we need to use `168.63.129.16`. We also need to use a different value in some onprem installations.

This adds the value when creating the helm release for chart-operator.
