### PR TITLE
Set force annotation for chart CR if it is set for the app CR

### DIFF
--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -10,4 +10,8 @@ const (
 	// CordonUntil is the name of the annotation that indicates
 	// the expiration date for this cordon rule.
 	CordonUntil = "app-operator.giantswarm.io/cordon-until"
+
+	// ForceHelmUpgrade is the name of the annotation that controls whether force
+	// is used when upgrading the Helm release.
+	ForceHelmUpgrade = "chart-operator.giantswarm.io/force-helm-upgrade"
 )

--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/app-operator/pkg/annotation"
 	"github.com/giantswarm/app-operator/pkg/label"
 	"github.com/giantswarm/app-operator/pkg/tarball"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
@@ -49,7 +50,25 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		},
 	}
 
+	annotations := generateAnnotations(cr.GetAnnotations())
+	if len(annotations) > 0 {
+		chartCR.Annotations = annotations
+	}
+
 	return chartCR, nil
+}
+
+func generateAnnotations(input map[string]string) map[string]string {
+	annotations := map[string]string{}
+
+	// ForceHelmUpgrade has been set for this app CR so this needs to be passed
+	// on to the chart CR.
+	val, ok := input[annotation.ForceHelmUpgrade]
+	if ok {
+		annotations[annotation.ForceHelmUpgrade] = val
+	}
+
+	return annotations
 }
 
 func generateConfig(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog, chartNamespace string) v1alpha1.ChartSpecConfig {

--- a/service/controller/app/v1/resource/chart/desired_test.go
+++ b/service/controller/app/v1/resource/chart/desired_test.go
@@ -174,6 +174,67 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "case 2: set helm force upgrade annotation",
+			obj: &v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"chart-operator.giantswarm.io/force-helm-upgrade": "true",
+					},
+					Name:      "my-cool-prometheus",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                                "prometheus",
+						"app-operator.giantswarm.io/version": "1.0.0",
+						"giantswarm.io/managed-by":           "cluster-operator",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "prometheus",
+					Namespace: "monitoring",
+					Version:   "1.0.0",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						InCluster: true,
+					},
+				},
+			},
+			appCatalog: v1alpha1.AppCatalog{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "giantswarm",
+				},
+				Spec: v1alpha1.AppCatalogSpec{
+					Title: "Giant Swarm",
+					Storage: v1alpha1.AppCatalogSpecStorage{
+						Type: "helm",
+						URL:  "https://giantswarm.github.com/app-catalog/",
+					},
+				},
+			},
+			expectedChart: &v1alpha1.Chart{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Chart",
+					APIVersion: "application.giantswarm.io",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"chart-operator.giantswarm.io/force-helm-upgrade": "true",
+					},
+					Name:      "my-cool-prometheus",
+					Namespace: "giantswarm",
+					Labels: map[string]string{
+						"app":                                  "prometheus",
+						"chart-operator.giantswarm.io/version": "1.0.0",
+						"giantswarm.io/managed-by":             "app-operator",
+					},
+				},
+				Spec: v1alpha1.ChartSpec{
+					Name:       "my-cool-prometheus",
+					Namespace:  "monitoring",
+					TarballURL: "https://giantswarm.github.com/app-catalog/prometheus-1.0.0.tgz",
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
When upgrading chart-operator with helm 2.14.3 vendored it fails with this error.

```
/go/src/github.com/giantswarm/chart-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:607:
	rpc error: code = Unknown desc = kind ClusterRole with the name "chart-operator-psp-user" already exists in the cluster and wasn't defined in the previous release. Before upgrading, please either delete the resource from the cluster or remove it from the chart
```

The fix is to use `helm.ForceUpgrade(true)` so the `chart-operator-psp-user` is deleted as part of the upgrade.

But the annotation that controls this is only set on the app CR. It needs to be passed on to the chart CR.


