### PR TITLE
Compare UserConfig for chart's cm, secret config

### DIFF
--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -96,7 +96,7 @@ func generateConfig(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog, chartNamesp
 }
 
 func hasConfigMap(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog) bool {
-	if key.AppConfigMapName(cr) != "" || key.UserConfigMapName(cr) != "" || key.AppCatalogConfigMapName(appCatalog) != "" {
+	if key.AppConfigMapName(cr) != "" || key.AppCatalogConfigMapName(appCatalog) != "" || key.UserConfigMapName(cr) != "" {
 		return true
 	}
 
@@ -104,7 +104,7 @@ func hasConfigMap(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog) bool {
 }
 
 func hasSecret(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog) bool {
-	if key.AppSecretName(cr) != "" || key.UserSecretName(cr) != "" || key.AppCatalogSecretName(appCatalog) != "" {
+	if key.AppSecretName(cr) != "" || key.AppCatalogSecretName(appCatalog) != "" || key.UserSecretName(cr) != "" {
 		return true
 	}
 

--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -96,7 +96,7 @@ func generateConfig(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog, chartNamesp
 }
 
 func hasConfigMap(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog) bool {
-	if key.AppConfigMapName(cr) != "" || key.AppCatalogConfigMapName(appCatalog) != "" {
+	if key.AppConfigMapName(cr) != "" || key.UserConfigMapName(cr) != "" || key.AppCatalogConfigMapName(appCatalog) != "" {
 		return true
 	}
 
@@ -104,7 +104,7 @@ func hasConfigMap(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog) bool {
 }
 
 func hasSecret(cr v1alpha1.App, appCatalog v1alpha1.AppCatalog) bool {
-	if key.AppSecretName(cr) != "" || key.AppCatalogSecretName(appCatalog) != "" {
+	if key.AppSecretName(cr) != "" || key.UserSecretName(cr) != "" || key.AppCatalogSecretName(appCatalog) != "" {
 		return true
 	}
 


### PR DESCRIPTION
When app-operator reconciles `app` CR and creating/updating `chart` CR, it should also consider changes from `userConfigmap`. 

This changes to look it up to the changes from userConfig, too. 