### PR TITLE
Cancel reconciliation when there are too many tiller pods

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -327,11 +327,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6e79c6bdfd7a2f36963340ab35e08edbbd35c365974b3feecf7a8411e32c20c5"
+  digest = "1:28713da767adbb226195e7e48e02975d3291bcf7607f91a34bc3db0a75e079a2"
   name = "github.com/giantswarm/helmclient"
   packages = ["."]
   pruneopts = "UT"
-  revision = "730d3617e9ffc0e22801d9ea231f70c0de2d9681"
+  revision = "386916cdcc22ddd332022e045d26d0e345562116"
 
 [[projects]]
   branch = "master"

--- a/service/controller/app/v1/resource/tiller/resource.go
+++ b/service/controller/app/v1/resource/tiller/resource.go
@@ -68,7 +68,15 @@ func (r *Resource) ensureTillerInstalled(ctx context.Context, helmClient helmcli
 	} else if helmclient.IsTillerNotRunningError(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "no running tiller pod")
 
-		// Can't find a tiller pod in starting phase, We will retry on next reconciliation loop.
+		// Can't find a tiller pod in starting phase. We will retry on next reconciliation loop.
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+
+		return nil
+	} else if helmclient.IsTooManyResults(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "currently too many tiller pods due to upgrade")
+
+		// Too many tiller pods due to upgrade. We will retry on next reconciliation loop.
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
 		reconciliationcanceledcontext.SetCanceled(ctx)
 

--- a/vendor/github.com/giantswarm/helmclient/README.md
+++ b/vendor/github.com/giantswarm/helmclient/README.md
@@ -1,27 +1,24 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/helmclient.svg?&style=shield)](https://circleci.com/gh/giantswarm/helmclient)
+[![GoDoc](https://godoc.org/github.com/giantswarm/helmclient?status.svg)](http://godoc.org/github.com/giantswarm/helmclient) [![CircleCI](https://circleci.com/gh/giantswarm/helmclient.svg?&style=shield)](https://circleci.com/gh/giantswarm/helmclient)
 
 # helmclient
 
-Package helmclient implements Helm related primitives to work against Tiller.
+Package helmclient implements [Helm] related primitives to work against helm
+releases. Currently supports Helm 2 and connects to the Tiller gRPC API using
+a port forwarding connection.
 
-## Projects using `helmclient`
+## Interface
 
-### Test libraries
+See `helmclient.Interface` in [spec.go] for supported methods.
 
-- https://github.com/giantswarm/e2e-harness
-- https://github.com/giantswarm/e2etests
+## Related libraries
 
-### Libraries
-
-- https://github.com/giantswarm/tenantcluster
-
-### Services & operators
-
-- https://github.com/giantswarm/aws-operator
-- https://github.com/giantswarm/chart-operator
-- https://github.com/giantswarm/cluster-operator
+[k8sportforward] is used to establish a port forwarding conection with Tiller. 
 
 ## License
 
 helmclient is under the Apache 2.0 license. See the [LICENSE](LICENSE) file
 for details.
+
+[Helm]: https://github.com/helm/helm
+[k8sportforward]: https://github.com/giantswarm/k8sportforward
+[spec.go]: https://github.com/giantswarm/helmclient/blob/master/spec.go

--- a/vendor/github.com/giantswarm/helmclient/ensure_tiller_installed.go
+++ b/vendor/github.com/giantswarm/helmclient/ensure_tiller_installed.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -122,6 +123,155 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 		}
 	}
 
+	// Create a clusterrole to allow Tiller to use PSPs
+	{
+		name := fmt.Sprintf("%s-psp", tillerPodName)
+
+		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating clusterrole %#q", name))
+
+		cr := &rbacv1.ClusterRole{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "rbac.authorization.k8s.io/v1",
+				Kind:       "ClusterRole",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{
+						"extensions",
+					},
+					Resources: []string{
+						"podsecuritypolicies",
+					},
+					ResourceNames: []string{
+						name,
+					},
+					Verbs: []string{
+						"use",
+					},
+				},
+			},
+		}
+
+		_, err := c.k8sClient.RbacV1().ClusterRoles().Create(cr)
+		if errors.IsAlreadyExists(err) {
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrole %#q already exists", name))
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created clusterrole %#q", name))
+		}
+	}
+
+	// Create a clusterrole binding for Tiller to use PSPs.
+	{
+		serviceAccountName := tillerPodName
+		serviceAccountNamespace := c.tillerNamespace
+
+		name := fmt.Sprintf("%s-psp", tillerPodName)
+
+		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating clusterrolebinding %#q", name))
+
+		crb := &rbacv1.ClusterRoleBinding{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "rbac.authorization.k8s.io/v1",
+				Kind:       "ClusterRoleBinding",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccountName,
+					Namespace: serviceAccountNamespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     name,
+			},
+		}
+
+		_, err := c.k8sClient.RbacV1().ClusterRoleBindings().Create(crb)
+		if errors.IsAlreadyExists(err) {
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("clusterrolebinding %#q already exists", name))
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created clusterrolebinding %#q", name))
+		}
+	}
+
+	// create a pod security policy for tiller to ensure it runs with least possible privileges.
+	{
+		podSecurityPolicyNamespace := c.tillerNamespace
+		minRunAsID := int64(1)
+		maxRunAsID := int64(65535)
+		allowEscalation := true
+
+		name := fmt.Sprintf("%s-psp", tillerPodName)
+
+		c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating podsecuritypolicy %#q", name))
+
+		psp := &policyv1beta1.PodSecurityPolicy{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "policy/v1beta1",
+				Kind:       "PodSecurityPolicy",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: podSecurityPolicyNamespace,
+			},
+			Spec: policyv1beta1.PodSecurityPolicySpec{
+				Privileged: false,
+				Volumes: []policyv1beta1.FSType{
+					"secret",
+				},
+				HostNetwork: false,
+				HostPID:     false,
+				HostIPC:     false,
+				SELinux: policyv1beta1.SELinuxStrategyOptions{
+					Rule: "RunAsAny",
+				},
+				RunAsUser: policyv1beta1.RunAsUserStrategyOptions{
+					Rule: "RunAsAny",
+				},
+				RunAsGroup: &policyv1beta1.RunAsGroupStrategyOptions{
+					Rule: "RunAsAny",
+				},
+				SupplementalGroups: policyv1beta1.SupplementalGroupsStrategyOptions{
+					Rule: "RunAsAny",
+				},
+				FSGroup: policyv1beta1.FSGroupStrategyOptions{
+					Rule: "MustRunAs",
+					Ranges: []policyv1beta1.IDRange{
+						{
+							Min: minRunAsID,
+							Max: maxRunAsID,
+						},
+					},
+				},
+				AllowPrivilegeEscalation: &allowEscalation,
+			},
+		}
+
+		_, err := c.k8sClient.PolicyV1beta1().PodSecurityPolicies().Create(psp)
+		if errors.IsAlreadyExists(err) {
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("podsecuritypolicy %#q already exists", name))
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created podsecuritypolicy %#q", name))
+		}
+	}
+
 	// Create the network policy for tiller so it is allowed to do its job in case all traffic is blocked.
 	{
 		networkPolicyName := tillerPodName
@@ -201,6 +351,8 @@ func (c *Client) EnsureTillerInstalledWithValues(ctx context.Context, values []s
 				// Fall through as we need to install Tiller.
 				installTiller = true
 				return nil
+			} else if IsTooManyResults(err) {
+				return backoff.Permanent(microerror.Mask(err))
 			} else if err != nil {
 				return microerror.Mask(err)
 			}

--- a/vendor/github.com/giantswarm/helmclient/error.go
+++ b/vendor/github.com/giantswarm/helmclient/error.go
@@ -86,6 +86,15 @@ func IsNotFound(err error) bool {
 	return microerror.Cause(err) == notFoundError
 }
 
+var pullChartFailedError = &microerror.Error{
+	Kind: "pullChartFailedError",
+}
+
+// IsPullChartFailedError asserts pullChartFailedError.
+func IsPullChartFailedError(err error) bool {
+	return microerror.Cause(err) == pullChartFailedError
+}
+
 var (
 	releaseAlreadyExistsRegexp = regexp.MustCompile(`release named \S+ already exists`)
 )

--- a/vendor/github.com/giantswarm/helmclient/pull_chart_tarball.go
+++ b/vendor/github.com/giantswarm/helmclient/pull_chart_tarball.go
@@ -37,7 +37,7 @@ func (c *Client) doFile(ctx context.Context, req *http.Request) (string, error) 
 	o := func() error {
 		resp, err := c.httpClient.Do(req)
 		if isNoSuchHostError(err) {
-			return backoff.Permanent(microerror.Maskf(executionFailedError, "no such host %#q", req.Host))
+			return backoff.Permanent(microerror.Maskf(pullChartFailedError, "no such host %#q", req.Host))
 		} else if err != nil {
 			return microerror.Mask(err)
 		}
@@ -52,7 +52,7 @@ func (c *Client) doFile(ctx context.Context, req *http.Request) (string, error) 
 			// Github pages 404 produces full HTML page which
 			// obscures the logs.
 			if resp.StatusCode == http.StatusNotFound {
-				return backoff.Permanent(microerror.Maskf(executionFailedError, fmt.Sprintf("got StatusCode %d for url %#q", resp.StatusCode, req.URL.String())))
+				return backoff.Permanent(microerror.Maskf(pullChartFailedError, fmt.Sprintf("got StatusCode %d for url %#q", resp.StatusCode, req.URL.String())))
 			}
 			return microerror.Maskf(executionFailedError, fmt.Sprintf("got StatusCode %d for url %#q with body %s", resp.StatusCode, req.URL.String(), buf.String()))
 		}


### PR DESCRIPTION
Towards giantswarm/giantswarm#7603

Same as https://github.com/giantswarm/chart-operator/pull/313. Final PR will backport fix to old cluster-operator versions.