### PR TITLE
Update master toleration label for 1.16

### DIFF
--- a/service/controller/app/v1/resource/tiller/resource.go
+++ b/service/controller/app/v1/resource/tiller/resource.go
@@ -49,7 +49,7 @@ func (r *Resource) ensureTillerInstalled(ctx context.Context, helmClient helmcli
 	values := []string{
 		"spec.template.spec.priorityClassName=giantswarm-critical",
 		"spec.template.spec.tolerations[0].effect=NoSchedule",
-		"spec.template.spec.tolerations[0].key=node-role.kubernetes.io/master",
+		"spec.template.spec.tolerations[0].key=node.kubernetes.io/master",
 		"spec.template.spec.tolerations[0].operator=Exists",
 	}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7824

Kubernetes 1.16 disallows the use of the `node-role.kubernetes.io/master` label on nodes (see https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/0000-20170814-bounding-self-labeling-kubelets.md#proposal). We have this hardcoded in lots of places so I thought I would get started updating them now. As far as I know, we have four role labels on every node. This should therefore be a backwards compatible change.

This could be considered to be a part of https://github.com/giantswarm/app-operator/pull/168 or https://github.com/giantswarm/giantswarm/issues/7428 or both.