### PR TITLE
Delete unused watch_namespace var

### DIFF
--- a/helm/app-operator-chart/templates/configmap.yaml
+++ b/helm/app-operator-chart/templates/configmap.yaml
@@ -19,5 +19,3 @@ data:
         registry: '{{ .Values.Installation.V1.Registry.Domain }}' 
       kubernetes:
         incluster: true
-        watch:
-          namespace: '{{ .Values.watchNamespace }}'

--- a/service/controller/app/app.go
+++ b/service/controller/app/app.go
@@ -20,7 +20,6 @@ type Config struct {
 
 	ChartNamespace string
 	ImageRegistry  string
-	WatchNamespace string
 }
 
 type App struct {
@@ -52,7 +51,6 @@ func NewApp(config Config) (*App, error) {
 			ImageRegistry:  config.ImageRegistry,
 			K8sClient:      config.K8sClient,
 			Logger:         config.Logger,
-			WatchNamespace: config.WatchNamespace,
 		}
 
 		resourceSetV1, err = v1.NewResourceSet(c)

--- a/service/controller/app/v1/resource/chart/create_test.go
+++ b/service/controller/app/v1/resource/chart/create_test.go
@@ -74,7 +74,6 @@ func Test_Resource_newCreateChange(t *testing.T) {
 		Logger:    microloggertest.New(),
 
 		ChartNamespace: "giantswarm",
-		WatchNamespace: "default",
 	}
 	r, err := New(c)
 	if err != nil {

--- a/service/controller/app/v1/resource/chart/current_test.go
+++ b/service/controller/app/v1/resource/chart/current_test.go
@@ -96,7 +96,6 @@ func Test_Resource_GetCurrentState(t *testing.T) {
 				Logger:    microloggertest.New(),
 
 				ChartNamespace: "giantswarm",
-				WatchNamespace: "default",
 			}
 			r, err := New(c)
 			if err != nil {

--- a/service/controller/app/v1/resource/chart/delete_test.go
+++ b/service/controller/app/v1/resource/chart/delete_test.go
@@ -65,7 +65,6 @@ func Test_Resource_newDeleteChange(t *testing.T) {
 		Logger:    microloggertest.New(),
 
 		ChartNamespace: "giantswarm",
-		WatchNamespace: "default",
 	}
 	r, err := New(c)
 	if err != nil {

--- a/service/controller/app/v1/resource/chart/desired_test.go
+++ b/service/controller/app/v1/resource/chart/desired_test.go
@@ -244,7 +244,6 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				Logger:    microloggertest.New(),
 
 				ChartNamespace: "giantswarm",
-				WatchNamespace: "default",
 			}
 			r, err := New(c)
 			if err != nil {

--- a/service/controller/app/v1/resource/chart/resource.go
+++ b/service/controller/app/v1/resource/chart/resource.go
@@ -26,7 +26,6 @@ type Config struct {
 
 	// Settings.
 	ChartNamespace string
-	WatchNamespace string
 }
 
 // Resource implements the chart resource.
@@ -37,7 +36,6 @@ type Resource struct {
 
 	// Settings.
 	chartNamespace string
-	watchNamespace string
 }
 
 // New creates a new configured chart resource.
@@ -58,7 +56,6 @@ func New(config Config) (*Resource, error) {
 		logger:    config.Logger,
 
 		chartNamespace: config.ChartNamespace,
-		watchNamespace: config.WatchNamespace,
 	}
 
 	return r, nil

--- a/service/controller/app/v1/resource/chart/update_test.go
+++ b/service/controller/app/v1/resource/chart/update_test.go
@@ -83,7 +83,6 @@ func Test_Resource_newUpdateChange(t *testing.T) {
 		Logger:    microloggertest.New(),
 
 		ChartNamespace: "giantswarm",
-		WatchNamespace: "default",
 	}
 	r, err := New(c)
 	if err != nil {

--- a/service/controller/app/v1/resource_set.go
+++ b/service/controller/app/v1/resource_set.go
@@ -39,7 +39,6 @@ type ResourceSetConfig struct {
 	// Settings.
 	ChartNamespace string
 	ImageRegistry  string
-	WatchNamespace string
 }
 
 // NewResourceSet returns a configured App controller ResourceSet.
@@ -124,7 +123,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			Logger:    config.Logger,
 
 			ChartNamespace: config.ChartNamespace,
-			WatchNamespace: config.WatchNamespace,
 		}
 
 		ops, err := chart.New(c)

--- a/service/controller/appcatalog/appcatalog.go
+++ b/service/controller/appcatalog/appcatalog.go
@@ -15,8 +15,6 @@ import (
 type Config struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
-
-	WatchNamespace string
 }
 
 type AppCatalog struct {

--- a/service/service.go
+++ b/service/service.go
@@ -97,8 +97,6 @@ func New(config Config) (*Service, error) {
 		c := appcatalog.Config{
 			Logger:    config.Logger,
 			K8sClient: k8sClient,
-
-			WatchNamespace: config.Viper.GetString(config.Flag.Service.Kubernetes.Watch.Namespace),
 		}
 
 		appCatalogController, err = appcatalog.NewAppCatalog(c)
@@ -117,7 +115,6 @@ func New(config Config) (*Service, error) {
 
 			ChartNamespace: config.Viper.GetString(config.Flag.Service.Chart.Namespace),
 			ImageRegistry:  config.Viper.GetString(config.Flag.Service.Image.Registry),
-			WatchNamespace: config.Viper.GetString(config.Flag.Service.Kubernetes.Watch.Namespace),
 		}
 
 		appController, err = app.NewApp(c)


### PR DESCRIPTION
`WatchNamespace` is not used anywhere. 
We can safely delete this. 