### PR TITLE
Fix namespace lookup result log messages

### DIFF
--- a/service/controller/app/v1/resource/namespace/current.go
+++ b/service/controller/app/v1/resource/namespace/current.go
@@ -49,7 +49,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 		m, err := cc.K8sClient.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found namespace %#q in tenant cluster %#q", namespace, key.ClusterID(cr)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find namespace %#q in tenant cluster %#q", namespace, key.ClusterID(cr)))
 			// fall through
 		} else if tenant.IsAPINotAvailable(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster api not available")
@@ -60,7 +60,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 			return nil, microerror.Mask(err)
 		} else {
 			ns = m
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find namespace %#q in tenant cluster %#q", namespace, key.ClusterID(cr)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found namespace %#q in tenant cluster %#q", namespace, key.ClusterID(cr)))
 		}
 	}
 


### PR DESCRIPTION
Success and not-found error log messages seem to have been mixed up.