### PR TITLE
Fix log message copy/paste error

### DIFF
--- a/service/controller/app/v1/resource/secret/desired.go
+++ b/service/controller/app/v1/resource/secret/desired.go
@@ -28,7 +28,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 
 	mergedData, err := r.values.MergeSecretData(ctx, cr, cc.AppCatalog)
 	if values.IsNotFound(err) {
-		r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("dependent configMaps are not found"), "stack", fmt.Sprintf("%#v", err))
+		r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("dependent secrets are not found"), "stack", fmt.Sprintf("%#v", err))
 		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)


### PR DESCRIPTION
While analyzing https://github.com/giantswarm/giantswarm/issues/8187 found this copy/paste error in log message.