### PR TITLE
Adjust e2e test timeout from default 10m to 20m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ e2eTest: &e2eTest
             -e E2E_KUBECONFIG=/e2e/kubeconfig \
             -e CIRCLE_SHA1=${CIRCLE_SHA1} \
             -w /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} \
-            golang:1 go test -v -tags k8srequired ./${E2E_TEST_DIR}/
+            golang:1 go test -timeout 20m -v -tags k8srequired ./${E2E_TEST_DIR}/
 
     - run:
         name: Debug


### PR DESCRIPTION
Basic e2e test often fails due to go test timeout (e.g. see [here](https://circleci.com/gh/giantswarm/app-operator/2453)), it seems to take longer. This PR extends the timeout to 20min.