### PR TITLE
Copy annotations into chart CR with chart-operator prefix

### DIFF
--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -3,6 +3,9 @@
 package annotation
 
 const (
+	// ChartOperatorPrefix is the prefix of the annotation that controls the logic inside chart-operator
+	ChartOperatorPrefix = "chart-operator.giantswarm.io"
+
 	// CordonReason is the name of the annotation that indicates
 	// the reason of why app-operator should not apply any update to this app CR.
 	CordonReason = "app-operator.giantswarm.io/cordon-reason"
@@ -10,8 +13,4 @@ const (
 	// CordonUntil is the name of the annotation that indicates
 	// the expiration date for this cordon rule.
 	CordonUntil = "app-operator.giantswarm.io/cordon-until"
-
-	// ForceHelmUpgrade is the name of the annotation that controls whether force
-	// is used when upgrading the Helm release.
-	ForceHelmUpgrade = "chart-operator.giantswarm.io/force-helm-upgrade"
 )

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -3,7 +3,7 @@
 package annotation
 
 const (
-	// ChartOperatorPrefix is the prefix of the annotation that controls the logic inside chart-operator
+	// ChartOperatorPrefix is the prefix for annotations that control logic inside chart-operator.
 	ChartOperatorPrefix = "chart-operator.giantswarm.io"
 
 	// CordonReason is the name of the annotation that indicates

--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/app-operator/pkg/annotation"
 	"github.com/giantswarm/app-operator/pkg/label"
 	"github.com/giantswarm/app-operator/pkg/project"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
@@ -75,7 +76,7 @@ func generateAnnotations(input map[string]string) map[string]string {
 
 	for k, val := range input {
 		// Copy all annotations which has a prefix with chart-operator.giantswarm.io.
-		if strings.HasPrefix(k, "chart-operator.giantswarm.io") {
+		if strings.HasPrefix(k, annotation.ChartOperatorPrefix) {
 			annotations[k] = val
 		}
 	}

--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -74,10 +74,10 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 func generateAnnotations(input map[string]string) map[string]string {
 	annotations := map[string]string{}
 
-	for k, val := range input {
+	for k, v := range input {
 		// Copy all annotations which has a prefix with chart-operator.giantswarm.io.
 		if strings.HasPrefix(k, annotation.ChartOperatorPrefix) {
-			annotations[k] = val
+			annotations[k] = v
 		}
 	}
 

--- a/service/controller/app/v1/resource/chart/desired.go
+++ b/service/controller/app/v1/resource/chart/desired.go
@@ -3,13 +3,13 @@ package chart
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/appcatalog"
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/app-operator/pkg/annotation"
 	"github.com/giantswarm/app-operator/pkg/label"
 	"github.com/giantswarm/app-operator/pkg/project"
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
@@ -73,11 +73,11 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 func generateAnnotations(input map[string]string) map[string]string {
 	annotations := map[string]string{}
 
-	// ForceHelmUpgrade has been set for this app CR so this needs to be passed
-	// on to the chart CR.
-	val, ok := input[annotation.ForceHelmUpgrade]
-	if ok {
-		annotations[annotation.ForceHelmUpgrade] = val
+	for k, val := range input {
+		// Copy all annotations which has a prefix with chart-operator.giantswarm.io.
+		if strings.HasPrefix(k, "chart-operator.giantswarm.io") {
+			annotations[k] = val
+		}
 	}
 
 	return annotations

--- a/service/controller/app/v1/resource/chart/resource.go
+++ b/service/controller/app/v1/resource/chart/resource.go
@@ -2,11 +2,14 @@ package chart
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/app-operator/pkg/annotation"
 )
 
 const (
@@ -75,6 +78,19 @@ func equals(current, desired *v1alpha1.Chart) bool {
 	}
 	if !reflect.DeepEqual(current.Labels, desired.Labels) {
 		return false
+	}
+	for k, desiredValue := range desired.Annotations {
+		if !strings.HasPrefix(k, annotation.ChartOperatorPrefix) {
+			continue
+		}
+
+		if currentValue, ok := current.Annotations[k]; !ok {
+			return false
+		} else {
+			if currentValue != desiredValue {
+				return false
+			}
+		}
 	}
 
 	return true

--- a/service/controller/app/v1/resource/chart/resource.go
+++ b/service/controller/app/v1/resource/chart/resource.go
@@ -79,17 +79,18 @@ func equals(current, desired *v1alpha1.Chart) bool {
 	if !reflect.DeepEqual(current.Labels, desired.Labels) {
 		return false
 	}
+
 	for k, desiredValue := range desired.Annotations {
 		if !strings.HasPrefix(k, annotation.ChartOperatorPrefix) {
 			continue
 		}
 
-		if currentValue, ok := current.Annotations[k]; !ok {
+		currentValue, ok := current.Annotations[k]
+		if !ok {
 			return false
-		} else {
-			if currentValue != desiredValue {
-				return false
-			}
+		}
+		if currentValue != desiredValue {
+			return false
 		}
 	}
 


### PR DESCRIPTION
During looking into https://github.com/giantswarm/giantswarm/issues/8082, I found out we do not compare annotations between desired and current status. 

We would copy annotations from app CR only with `chart-operator.giantswarm.io` prefix and compare the value as well. 