### PR TITLE
Handle tenant cluster being unavailable in chart resource

### DIFF
--- a/service/controller/app/v1/resource/chart/create.go
+++ b/service/controller/app/v1/resource/chart/create.go
@@ -30,9 +30,9 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created Chart CR %#q in namespace %#q", chart.Name, chart.Namespace))
 		} else if err != nil {
 			return microerror.Mask(err)
-		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created Chart CR %#q in namespace %#q", chart.Name, chart.Namespace))
 		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created Chart CR %#q in namespace %#q", chart.Name, chart.Namespace))
 	}
 
 	return nil


### PR DESCRIPTION
Fixing error found in alert from viking.

```
E 01/17 15:59:12 /apis/application.giantswarm.io/v1alpha1/namespaces/mfnc6/apps/kube-state-metrics failed processing event | operatorkit/controller/controller.go:493 | event=update | version=165366366
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:599:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/crud/resource.go:141:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/metricsresource/crud_resource.go:115:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource.go:166:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/backoff/retry.go:23:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/crud_resource.go:154:
	/go/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/chart/create.go:32:
	Post https://api.mfnc6.k8s.eu-central-1.aws.cps.vodafone.com/apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts: dial tcp 18.185.205.65:443: i/o timeout
```

