### PR TITLE
Cancel reconciliation instead of erroring if chart-operator is not ready

### DIFF
--- a/service/controller/app/v1/resource/chartoperator/resource.go
+++ b/service/controller/app/v1/resource/chartoperator/resource.go
@@ -159,7 +159,7 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 		// Wait for chart-operator to be deployed. If it takes longer than
 		// the timeout the chartconfig CRs will be created during the next
 		// reconciliation loop.
-		b := backoff.NewConstant(30*time.Second, 5*time.Second)
+		b := backoff.NewConstant(20*time.Second, 5*time.Second)
 		n := func(err error, delay time.Duration) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q deployment is not ready retrying in %s", release, delay), "stack", fmt.Sprintf("%#v", err))
 		}

--- a/service/controller/app/v1/resource/chartoperator/resource.go
+++ b/service/controller/app/v1/resource/chartoperator/resource.go
@@ -159,7 +159,7 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 		// Wait for chart-operator to be deployed. If it takes longer than
 		// the timeout the chartconfig CRs will be created during the next
 		// reconciliation loop.
-		b := backoff.NewConstant(20*time.Second, 10*time.Second)
+		b := backoff.NewConstant(30*time.Second, 5*time.Second)
 		n := func(err error, delay time.Duration) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q deployment is not ready retrying in %s", release, delay), "stack", fmt.Sprintf("%#v", err))
 		}


### PR DESCRIPTION
There are flapping alerts in gorilla on cluster creation because chart-operator is not becoming ready in time.

This cancels the reconciliation so we retry in the next loop when it should be ready. If chart-operator is not installed there will be an alert.

The current bootstrap process is error prone. So we want to create the chard CRD via ignition in https://github.com/giantswarm/giantswarm/issues/8555. 

```W 01/23 08:27:02 /apis/application.giantswarm.io/v1alpha1/namespaces/t0t0f/apps/chart-operator chartoperatorv1 retrying due to error | operatorkit/resource/wrapper/retryresource/basic_resource.go:59 | event=update | version=65834790
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/basic_resource.go:52:
	/go/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/chartoperator/create.go:70:
	/go/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/chartoperator/resource.go:169:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/backoff/retry.go:23:
	/go/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/chartoperator/resource.go:153:
	/go/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/chartoperator/resource.go:329: deployment `chart-operator` want 1 replicas 0 ready
	not ready error```



