### PR TITLE
Revert "Use k8sclient library in controller context (#199)"

### DIFF
--- a/service/controller/app/v1/controllercontext/context.go
+++ b/service/controller/app/v1/controllercontext/context.go
@@ -4,9 +4,10 @@ import (
 	"context"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/helmclient"
-	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
+	"k8s.io/client-go/kubernetes"
 )
 
 type contextKey string
@@ -15,8 +16,9 @@ const controllerKey contextKey = "controller"
 
 type Context struct {
 	AppCatalog v1alpha1.AppCatalog
+	G8sClient  versioned.Interface
 	HelmClient helmclient.Interface
-	K8sClient  k8sclient.Interface
+	K8sClient  kubernetes.Interface
 	Status     Status
 }
 

--- a/service/controller/app/v1/resource/chart/create.go
+++ b/service/controller/app/v1/resource/chart/create.go
@@ -25,7 +25,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			return microerror.Mask(err)
 		}
 
-		_, err = cc.K8sClient.G8sClient().ApplicationV1alpha1().Charts(chart.Namespace).Create(chart)
+		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(chart.Namespace).Create(chart)
 		if apierrors.IsAlreadyExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created Chart CR %#q in namespace %#q", chart.Name, chart.Namespace))
 		} else if err != nil {

--- a/service/controller/app/v1/resource/chart/current.go
+++ b/service/controller/app/v1/resource/chart/current.go
@@ -36,7 +36,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding chart %#q", name))
 
-	chart, err := cc.K8sClient.G8sClient().ApplicationV1alpha1().Charts(r.chartNamespace).Get(name, metav1.GetOptions{})
+	chart, err := cc.G8sClient.ApplicationV1alpha1().Charts(r.chartNamespace).Get(name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find chart %#q in namespace %#q", name, r.chartNamespace))
 		return nil, nil

--- a/service/controller/app/v1/resource/chart/current_test.go
+++ b/service/controller/app/v1/resource/chart/current_test.go
@@ -1,0 +1,129 @@
+package chart
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
+)
+
+func Test_Resource_GetCurrentState(t *testing.T) {
+	tests := []struct {
+		name          string
+		obj           *v1alpha1.App
+		returnedChart *v1alpha1.Chart
+		errorMatcher  func(error) bool
+	}{
+		{
+			name: "case 0: chart already created",
+			obj: &v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-cool-prometheus",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog: "giantswarm",
+					Version: "1.0.0",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						InCluster: true,
+					},
+					Name:      "kubernetes-prometheus",
+					Namespace: "monitoring",
+				},
+			},
+			returnedChart: &v1alpha1.Chart{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kubernetes-prometheus",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ChartSpec{
+					Name:       "my-cool-prometheus",
+					Namespace:  "monitoring",
+					TarballURL: "https://giantswarm.github.com/app-catalog/kubernetes-prometheus-1.0.0.tgz",
+				},
+			},
+		},
+		{
+			name: "case 1: chart not found",
+			obj: &v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-cool-prometheus",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog: "giantswarm",
+					Version: "1.0.0",
+					KubeConfig: v1alpha1.AppSpecKubeConfig{
+						InCluster: true,
+					},
+					Name:      "kubernetes-prometheus",
+					Namespace: "monitoring",
+				},
+			},
+			returnedChart: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := make([]runtime.Object, 0, 0)
+			if tc.returnedChart != nil {
+				objs = append(objs, tc.returnedChart)
+			}
+
+			g8sClient := fake.NewSimpleClientset(objs...)
+
+			var ctx context.Context
+			{
+				c := controllercontext.Context{
+					G8sClient: g8sClient,
+					K8sClient: k8sfake.NewSimpleClientset(),
+				}
+				ctx = controllercontext.NewContext(context.Background(), c)
+			}
+
+			c := Config{
+				G8sClient: g8sClient,
+				Logger:    microloggertest.New(),
+
+				ChartNamespace: "giantswarm",
+			}
+			r, err := New(c)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			result, err := r.GetCurrentState(ctx, tc.obj)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if err == nil && tc.errorMatcher == nil {
+				if result != nil {
+					chart, err := toChart(result)
+					if err != nil {
+						t.Fatalf("error == %#v, want nil", err)
+					}
+
+					if !reflect.DeepEqual(chart, *tc.returnedChart) {
+						t.Fatalf("want matching chart \n %s", cmp.Diff(chart, tc.returnedChart))
+					}
+				}
+			}
+		})
+	}
+}

--- a/service/controller/app/v1/resource/chart/delete.go
+++ b/service/controller/app/v1/resource/chart/delete.go
@@ -26,7 +26,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			return microerror.Mask(err)
 		}
 
-		err = cc.K8sClient.G8sClient().ApplicationV1alpha1().Charts(chart.Namespace).Delete(chart.Name, &metav1.DeleteOptions{})
+		err = cc.G8sClient.ApplicationV1alpha1().Charts(chart.Namespace).Delete(chart.Name, &metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already deleted Chart CR %#q in namespace %#q", chart.Name, chart.Namespace))
 		} else if err != nil {

--- a/service/controller/app/v1/resource/chart/update.go
+++ b/service/controller/app/v1/resource/chart/update.go
@@ -25,7 +25,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			return microerror.Mask(err)
 		}
 
-		_, err = cc.K8sClient.G8sClient().ApplicationV1alpha1().Charts(chart.Namespace).Update(chart)
+		_, err = cc.G8sClient.ApplicationV1alpha1().Charts(chart.Namespace).Update(chart)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/app/v1/resource/chartoperator/resource.go
+++ b/service/controller/app/v1/resource/chartoperator/resource.go
@@ -148,7 +148,7 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 		r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for ready chart-operator deployment")
 
 		o := func() error {
-			err := r.checkDeploymentReady(ctx, cc.K8sClient.K8sClient())
+			err := r.checkDeploymentReady(ctx, cc.K8sClient)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -231,7 +231,7 @@ func (r Resource) updateChartOperator(ctx context.Context, cr v1alpha1.App) erro
 		r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for ready chart-operator deployment")
 
 		o := func() error {
-			err := r.checkDeploymentReady(ctx, cc.K8sClient.K8sClient())
+			err := r.checkDeploymentReady(ctx, cc.K8sClient)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/app/v1/resource/clients/resource.go
+++ b/service/controller/app/v1/resource/clients/resource.go
@@ -5,13 +5,12 @@ import (
 	"time"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/helmclient"
-	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/kubeconfig"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 
 	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
 )
@@ -101,37 +100,30 @@ func (r *Resource) addClientsToContext(ctx context.Context, cr v1alpha1.App) err
 		}
 	}
 
-	var restConfig *rest.Config
-	{
-		restConfig, err = kubeConfig.NewRESTConfigForApp(ctx, cr)
-		if err != nil {
-			return microerror.Mask(err)
-		}
+	restConfig, err := kubeConfig.NewRESTConfigForApp(ctx, cr)
+	if err != nil {
+		return microerror.Mask(err)
 	}
 
-	var k8sClient k8sclient.Interface
 	{
-		c := k8sclient.ClientsConfig{
-			Logger: r.logger,
-			SchemeBuilder: k8sclient.SchemeBuilder{
-				// Add application scheme.
-				v1alpha1.AddToScheme,
-			},
-
-			RestConfig: restConfig,
-		}
-
-		k8sClient, err = k8sclient.NewClients(c)
+		g8sClient, err := versioned.NewForConfig(restConfig)
 		if err != nil {
 			return microerror.Mask(err)
 		}
+		cc.G8sClient = g8sClient
+	}
 
+	{
+		k8sClient, err := kubernetes.NewForConfig(restConfig)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 		cc.K8sClient = k8sClient
 	}
 
 	{
 		c := helmclient.Config{
-			K8sClient: k8sClient.K8sClient(),
+			K8sClient: cc.K8sClient,
 			Logger:    r.logger,
 
 			EnsureTillerInstalledMaxWait: 30 * time.Second,

--- a/service/controller/app/v1/resource/configmap/create.go
+++ b/service/controller/app/v1/resource/configmap/create.go
@@ -27,7 +27,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			return microerror.Mask(err)
 		}
 
-		_, err = cc.K8sClient.K8sClient().CoreV1().ConfigMaps(configMap.Namespace).Create(configMap)
+		_, err = cc.K8sClient.CoreV1().ConfigMaps(configMap.Namespace).Create(configMap)
 		if apierrors.IsAlreadyExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created configmap %#q in namespace %#q", configMap.Name, configMap.Namespace))
 		} else if tenant.IsAPINotAvailable(err) {

--- a/service/controller/app/v1/resource/configmap/current.go
+++ b/service/controller/app/v1/resource/configmap/current.go
@@ -36,7 +36,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding configmap %#q in namespace %#q", name, r.chartNamespace))
 
-	chart, err := cc.K8sClient.K8sClient().CoreV1().ConfigMaps(r.chartNamespace).Get(name, metav1.GetOptions{})
+	chart, err := cc.K8sClient.CoreV1().ConfigMaps(r.chartNamespace).Get(name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		// Return early as configmap does not exist.
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find configmap %#q in namespace %#q", name, r.chartNamespace))

--- a/service/controller/app/v1/resource/configmap/current_test.go
+++ b/service/controller/app/v1/resource/configmap/current_test.go
@@ -1,0 +1,192 @@
+package configmap
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
+	"github.com/giantswarm/app-operator/service/controller/app/v1/values"
+)
+
+func Test_Resource_GetCurrentState(t *testing.T) {
+	testCases := []struct {
+		name              string
+		obj               *v1alpha1.App
+		configMap         *corev1.ConfigMap
+		expectedConfigMap *corev1.ConfigMap
+		errorMatcher      func(error) bool
+	}{
+		{
+			name: "case 0: basic match",
+			obj: &v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "app-values",
+							Namespace: "default",
+						},
+					},
+					Namespace: "kube-system",
+				},
+			},
+			configMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"key": "value",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app-chart-values",
+					Namespace: "giantswarm",
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"key": "value",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app-chart-values",
+					Namespace: "giantswarm",
+				},
+			},
+		},
+		{
+			name: "case 1: no matching configmap",
+			obj: &v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "app-values",
+							Namespace: "default",
+						},
+					},
+					Namespace: "kube-system",
+				},
+			},
+			configMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"key": "value",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-app-values",
+					Namespace: "default",
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{},
+		},
+		{
+			name: "case 2: namespace does not match",
+			obj: &v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "app-values",
+							Namespace: "default",
+						},
+					},
+					Namespace: "kube-system",
+				},
+			},
+			configMap: &corev1.ConfigMap{
+				Data: map[string]string{
+					"key": "value",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "app-values",
+					Namespace: "default",
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{},
+		},
+		{
+			name: "case 3: no configmaps",
+			obj: &v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "app-values",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			expectedConfigMap: &corev1.ConfigMap{},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			objs := make([]runtime.Object, 0, 0)
+			if tc.configMap != nil {
+				objs = append(objs, tc.configMap)
+			}
+
+			k8sClient := clientgofake.NewSimpleClientset(objs...)
+
+			var err error
+
+			var ctx context.Context
+			{
+				c := controllercontext.Context{
+					K8sClient: k8sClient,
+				}
+				ctx = controllercontext.NewContext(context.Background(), c)
+			}
+
+			var valuesService *values.Values
+			{
+				c := values.Config{
+					K8sClient: clientgofake.NewSimpleClientset(),
+					Logger:    microloggertest.New(),
+				}
+
+				valuesService, err = values.New(c)
+				if err != nil {
+					t.Fatalf("error == %#v, want nil", err)
+				}
+			}
+
+			c := Config{
+				Logger: microloggertest.New(),
+				Values: valuesService,
+
+				ChartNamespace: "giantswarm",
+			}
+			r, err := New(c)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			result, err := r.GetCurrentState(ctx, tc.obj)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			configMap, err := toConfigMap(result)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			if !reflect.DeepEqual(configMap, tc.expectedConfigMap) {
+				t.Fatalf("want matching configmap \n %s", cmp.Diff(configMap, tc.expectedConfigMap))
+			}
+		})
+	}
+}

--- a/service/controller/app/v1/resource/configmap/delete.go
+++ b/service/controller/app/v1/resource/configmap/delete.go
@@ -26,7 +26,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			return microerror.Mask(err)
 		}
 
-		err = cc.K8sClient.K8sClient().CoreV1().ConfigMaps(configMap.Namespace).Delete(configMap.Name, &metav1.DeleteOptions{})
+		err = cc.K8sClient.CoreV1().ConfigMaps(configMap.Namespace).Delete(configMap.Name, &metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already deleted configmap %#q in namespace %#q", configMap.Name, configMap.Namespace))
 		} else if err != nil {

--- a/service/controller/app/v1/resource/configmap/update.go
+++ b/service/controller/app/v1/resource/configmap/update.go
@@ -25,7 +25,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			return microerror.Mask(err)
 		}
 
-		_, err = cc.K8sClient.K8sClient().CoreV1().ConfigMaps(configMap.Namespace).Update(configMap)
+		_, err = cc.K8sClient.CoreV1().ConfigMaps(configMap.Namespace).Update(configMap)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/app/v1/resource/secret/create.go
+++ b/service/controller/app/v1/resource/secret/create.go
@@ -27,7 +27,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 			return microerror.Mask(err)
 		}
 
-		_, err = cc.K8sClient.K8sClient().CoreV1().Secrets(secret.Namespace).Create(secret)
+		_, err = cc.K8sClient.CoreV1().Secrets(secret.Namespace).Create(secret)
 		if apierrors.IsAlreadyExists(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already created secret %#q in namespace %#q", secret.Name, secret.Namespace))
 		} else if tenant.IsAPINotAvailable(err) {

--- a/service/controller/app/v1/resource/secret/current.go
+++ b/service/controller/app/v1/resource/secret/current.go
@@ -36,7 +36,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding secret %#q in namespace %#q", name, r.chartNamespace))
 
-	chart, err := cc.K8sClient.K8sClient().CoreV1().Secrets(r.chartNamespace).Get(name, metav1.GetOptions{})
+	chart, err := cc.K8sClient.CoreV1().Secrets(r.chartNamespace).Get(name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		// Return early as secret does not exist.
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find secret %#q in namespace %#q", name, r.chartNamespace))

--- a/service/controller/app/v1/resource/secret/current_test.go
+++ b/service/controller/app/v1/resource/secret/current_test.go
@@ -1,0 +1,195 @@
+package secret
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
+	"github.com/giantswarm/app-operator/service/controller/app/v1/values"
+)
+
+func Test_Resource_GetCurrentState(t *testing.T) {
+	testCases := []struct {
+		name           string
+		obj            *v1alpha1.App
+		secret         *corev1.Secret
+		expectedSecret *corev1.Secret
+		errorMatcher   func(error) bool
+	}{
+		{
+			name: "case 0: basic match",
+			obj: &v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app",
+					Namespace: "giantswarm",
+				},
+				Spec: v1alpha1.AppSpec{
+					Config: v1alpha1.AppSpecConfig{
+						Secret: v1alpha1.AppSpecConfigSecret{
+							Name:      "app-secrets",
+							Namespace: "default",
+						},
+					},
+					Namespace: "kube-system",
+				},
+			},
+			secret: &corev1.Secret{
+				StringData: map[string]string{
+					"key": "value",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app-chart-secrets",
+					Namespace: "giantswarm",
+				},
+			},
+			expectedSecret: &corev1.Secret{
+				StringData: map[string]string{
+					"key": "value",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-app-chart-secrets",
+					Namespace: "giantswarm",
+				},
+			},
+		},
+		{
+			name: "case 1: no matching secret",
+			obj: &v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					Config: v1alpha1.AppSpecConfig{
+						Secret: v1alpha1.AppSpecConfigSecret{
+							Name:      "app-values",
+							Namespace: "default",
+						},
+					},
+					Namespace: "kube-system",
+				},
+			},
+			secret: &corev1.Secret{
+				StringData: map[string]string{
+					"key": "value",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-app-values",
+					Namespace: "default",
+				},
+			},
+			expectedSecret: &corev1.Secret{},
+		},
+		{
+			name: "case 2: namespace does not match",
+			obj: &v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					Config: v1alpha1.AppSpecConfig{
+						Secret: v1alpha1.AppSpecConfigSecret{
+							Name:      "app-values",
+							Namespace: "default",
+						},
+					},
+					Namespace: "kube-system",
+				},
+			},
+			secret: &corev1.Secret{
+				StringData: map[string]string{
+					"key": "value",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "app-values",
+					Namespace: "default",
+				},
+			},
+			expectedSecret: &corev1.Secret{},
+		},
+		{
+			name: "case 3: no secrets",
+			obj: &v1alpha1.App{
+				Spec: v1alpha1.AppSpec{
+					Config: v1alpha1.AppSpecConfig{
+						Secret: v1alpha1.AppSpecConfigSecret{
+							Name:      "app-values",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			expectedSecret: &corev1.Secret{},
+		},
+	}
+
+	var err error
+
+	var valuesService *values.Values
+	{
+		c := values.Config{
+			K8sClient: clientgofake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+
+		valuesService, err = values.New(c)
+		if err != nil {
+			t.Fatalf("error == %#v, want nil", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			objs := make([]runtime.Object, 0, 0)
+			if tc.secret != nil {
+				objs = append(objs, tc.secret)
+			}
+
+			g8sClient := fake.NewSimpleClientset()
+			k8sClient := clientgofake.NewSimpleClientset(objs...)
+
+			var ctx context.Context
+			{
+				c := controllercontext.Context{
+					G8sClient: g8sClient,
+					K8sClient: k8sClient,
+				}
+				ctx = controllercontext.NewContext(context.Background(), c)
+			}
+
+			c := Config{
+				Logger: microloggertest.New(),
+				Values: valuesService,
+
+				ChartNamespace: "giantswarm",
+			}
+			r, err := New(c)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			result, err := r.GetCurrentState(ctx, tc.obj)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			secret, err := toSecret(result)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			if !reflect.DeepEqual(secret, tc.expectedSecret) {
+				t.Fatalf("want matching secret \n %s", cmp.Diff(secret, tc.expectedSecret))
+			}
+		})
+	}
+}

--- a/service/controller/app/v1/resource/secret/delete.go
+++ b/service/controller/app/v1/resource/secret/delete.go
@@ -26,7 +26,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 			return microerror.Mask(err)
 		}
 
-		err = cc.K8sClient.K8sClient().CoreV1().Secrets(secret.Namespace).Delete(secret.Name, &metav1.DeleteOptions{})
+		err = cc.K8sClient.CoreV1().Secrets(secret.Namespace).Delete(secret.Name, &metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("already deleted secret %#q in namespace %#q", secret.Name, secret.Namespace))
 		} else if err != nil {

--- a/service/controller/app/v1/resource/secret/update.go
+++ b/service/controller/app/v1/resource/secret/update.go
@@ -25,7 +25,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 			return microerror.Mask(err)
 		}
 
-		_, err = cc.K8sClient.K8sClient().CoreV1().Secrets(secret.Namespace).Update(secret)
+		_, err = cc.K8sClient.CoreV1().Secrets(secret.Namespace).Update(secret)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/app/v1/resource/status/create.go
+++ b/service/controller/app/v1/resource/status/create.go
@@ -33,7 +33,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding status for chart %#q in namespace %#q", cr.Name, r.chartNamespace))
 
-	chart, err := cc.K8sClient.G8sClient().ApplicationV1alpha1().Charts(r.chartNamespace).Get(cr.Name, metav1.GetOptions{})
+	chart, err := cc.G8sClient.ApplicationV1alpha1().Charts(r.chartNamespace).Get(cr.Name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find chart %#q in namespace %#q", cr.Name, r.chartNamespace))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")

--- a/service/controller/app/v1/resource/status/create_test.go
+++ b/service/controller/app/v1/resource/status/create_test.go
@@ -1,0 +1,251 @@
+package status
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/app-operator/service/controller/app/v1/controllercontext"
+)
+
+func Test_Resource_EnsureCreated(t *testing.T) {
+	tests := []struct {
+		name           string
+		obj            *v1alpha1.App
+		chart          *v1alpha1.Chart
+		expectedStatus v1alpha1.AppStatus
+		errorMatcher   func(error) bool
+	}{
+		{
+			name: "case 0: update status flow",
+			obj: &v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prometheus",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                                "prometheus",
+						"app-operator.giantswarm.io/version": "1.0.0",
+						"giantswarm.io/managed-by":           "cluster-operator",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "prometheus",
+					Namespace: "monitoring",
+					Version:   "1.0.0",
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "giant-swarm-config",
+							Namespace: "giantswarm",
+						},
+						Secret: v1alpha1.AppSpecConfigSecret{
+							Name:      "giant-swarm-secret",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+			},
+			chart: &v1alpha1.Chart{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Chart",
+					APIVersion: "application.giantswarm.io",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prometheus",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                                  "prometheus",
+						"chart-operator.giantswarm.io/version": "1.0.0",
+						"giantswarm.io/managed-by":             "app-operator",
+					},
+				},
+				Spec: v1alpha1.ChartSpec{
+					Config:     v1alpha1.ChartSpecConfig{},
+					Name:       "my-cool-prometheus",
+					Namespace:  "monitoring",
+					TarballURL: "https://giantswarm.github.com/app-catalog/prometheus-1.0.0.tgz",
+				},
+				Status: v1alpha1.ChartStatus{
+					AppVersion: "0.1",
+					Release: v1alpha1.ChartStatusRelease{
+						LastDeployed: v1alpha1.DeepCopyTime{time.Date(2019, 1, 1, 13, 0, 0, 0, time.UTC)},
+						Status:       "DEPLOYED",
+					},
+					Version: "0.1.1",
+				},
+			},
+			expectedStatus: v1alpha1.AppStatus{
+				AppVersion: "0.1",
+				Release: v1alpha1.AppStatusRelease{
+					Status:       "DEPLOYED",
+					LastDeployed: v1alpha1.DeepCopyTime{time.Date(2019, 1, 1, 13, 0, 0, 0, time.UTC)},
+				},
+				Version: "0.1.1",
+			},
+		},
+		{
+			name: "case 1: status not updated",
+			obj: &v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-cool-prometheus",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                                "prometheus",
+						"app-operator.giantswarm.io/version": "1.0.0",
+						"giantswarm.io/managed-by":           "cluster-operator",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "prometheus",
+					Namespace: "monitoring",
+					Version:   "1.0.0",
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "giant-swarm-config",
+							Namespace: "giantswarm",
+						},
+						Secret: v1alpha1.AppSpecConfigSecret{
+							Name:      "giant-swarm-secret",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+				Status: v1alpha1.AppStatus{
+					Release: v1alpha1.AppStatusRelease{
+						Status:       "DEPLOYED",
+						LastDeployed: v1alpha1.DeepCopyTime{time.Date(2019, 1, 1, 13, 0, 0, 0, time.UTC)},
+					},
+				},
+			},
+			chart: &v1alpha1.Chart{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Chart",
+					APIVersion: "application.giantswarm.io",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prometheus",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                                  "prometheus",
+						"chart-operator.giantswarm.io/version": "1.0.0",
+						"giantswarm.io/managed-by":             "app-operator",
+					},
+				},
+				Spec: v1alpha1.ChartSpec{
+					Config:     v1alpha1.ChartSpecConfig{},
+					Name:       "my-cool-prometheus",
+					Namespace:  "monitoring",
+					TarballURL: "https://giantswarm.github.com/app-catalog/prometheus-1.0.0.tgz",
+				},
+				Status: v1alpha1.ChartStatus{
+					Release: v1alpha1.ChartStatusRelease{
+						LastDeployed: v1alpha1.DeepCopyTime{time.Date(2019, 1, 1, 13, 0, 0, 0, time.UTC)},
+						Status:       "DEPLOYED",
+					},
+				},
+			},
+			expectedStatus: v1alpha1.AppStatus{
+				Release: v1alpha1.AppStatusRelease{
+					LastDeployed: v1alpha1.DeepCopyTime{time.Date(2019, 1, 1, 13, 0, 0, 0, time.UTC)},
+					Status:       "DEPLOYED",
+				},
+			},
+		},
+		{
+			name: "case 2: cannot find chart",
+			obj: &v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-cool-prometheus",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                                "prometheus",
+						"app-operator.giantswarm.io/version": "1.0.0",
+						"giantswarm.io/managed-by":           "cluster-operator",
+					},
+				},
+				Spec: v1alpha1.AppSpec{
+					Catalog:   "giantswarm",
+					Name:      "prometheus",
+					Namespace: "monitoring",
+					Version:   "1.0.0",
+					Config: v1alpha1.AppSpecConfig{
+						ConfigMap: v1alpha1.AppSpecConfigConfigMap{
+							Name:      "giant-swarm-config",
+							Namespace: "giantswarm",
+						},
+						Secret: v1alpha1.AppSpecConfigSecret{
+							Name:      "giant-swarm-secret",
+							Namespace: "giantswarm",
+						},
+					},
+				},
+				Status: v1alpha1.AppStatus{},
+			},
+			expectedStatus: v1alpha1.AppStatus{
+				Release: v1alpha1.AppStatusRelease{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			var err error
+
+			objs := make([]runtime.Object, 0, 0)
+			if tc.obj != nil {
+				objs = append(objs, tc.obj)
+			}
+			if tc.chart != nil {
+				objs = append(objs, tc.chart)
+			}
+
+			g8sClient := fake.NewSimpleClientset(objs...)
+
+			c := Config{
+				G8sClient: g8sClient,
+				Logger:    microloggertest.New(),
+
+				ChartNamespace: "default",
+			}
+			r, err := New(c)
+			if err != nil {
+				t.Fatalf("error == %#v, want nil", err)
+			}
+
+			ctlConfig := controllercontext.Context{
+				G8sClient: g8sClient,
+			}
+			ctx := controllercontext.NewContext(context.Background(), ctlConfig)
+
+			err = r.EnsureCreated(ctx, tc.obj)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if err == nil && tc.errorMatcher == nil {
+				app, err := g8sClient.ApplicationV1alpha1().Apps(tc.obj.Namespace).Get(tc.obj.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("error == %#v, want nil", err)
+				}
+				if !reflect.DeepEqual(app.Status, tc.expectedStatus) {
+					t.Fatalf("want matching app.Status \n %s", cmp.Diff(app.Status, tc.expectedStatus))
+				}
+			}
+		})
+	}
+}

--- a/service/controller/app/v1/resource/tcnamespace/create.go
+++ b/service/controller/app/v1/resource/tcnamespace/create.go
@@ -53,7 +53,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating namespace %#q in tenant cluster %#q", ns.Name, key.ClusterID(cr)))
 
-	_, err = cc.K8sClient.K8sClient().CoreV1().Namespaces().Create(ns)
+	_, err = cc.K8sClient.CoreV1().Namespaces().Create(ns)
 	if apierrors.IsAlreadyExists(err) {
 		// fall through
 	} else if tenant.IsAPINotAvailable(err) {


### PR DESCRIPTION
This reverts commit a7b9dd332035c4ba6e963d5f97325b82cdbb3669.

```
E 02/07 14:29:53 /apis/application.giantswarm.io/v1alpha1/namespaces/pnwd0/apps/external-dns failed processing event | operatorkit/controller/controller.go:529 | controller=app-operator | event=update | loop=31 | version=184046598
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:635:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/metricsresource/basic_resource.go:43:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/basic_resource.go:64:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/backoff/retry.go:23:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/basic_resource.go:52:
	/go/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/clients/create.go:21:
	/go/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/clients/resource.go:126:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/k8sclient/clients.go:117:
	Get https://api.pnwd0.k8s.eu-central-1.aws.cps.vodafone.com/api?timeout=32s: dial tcp 3.123.220.27:443: i/o timeout
```

This doesn't work because k8sclient actually makes an API call :(

I'll need to change the library or my approach here.  

https://github.com/giantswarm/k8sclient/blob/1542917096d6cb2f12745ab24850a930a89dca6c/clients.go#L115

