### PR TITLE
Handle deleted secret

### DIFF
--- a/service/controller/app/v1/resource/chartoperator/create.go
+++ b/service/controller/app/v1/resource/chartoperator/create.go
@@ -23,16 +23,22 @@ func (r Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	// Resource is used to bootstrap chart-operator in tenant clusters.
+	// So for other apps we can skip this step.
+	if key.AppName(cr) != key.ChartOperatorAppName {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no need to install chart-operator for %#q", key.AppName(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
 	if key.InCluster(cr) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q uses InCluster kubeconfig no need to install chart operator", key.AppName(cr)))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "cancelling the resource")
 		return nil
 	}
 
-	// Resource is used to bootstrap chart-operator in tenant clusters.
-	// So for other apps we can skip this step.
-	if key.AppName(cr) != key.ChartOperatorAppName {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no need to install chart-operator for %#q", key.AppName(cr)))
+	if cc.Status.TenantCluster.IsUnavailable {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is unavailable")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}

--- a/service/controller/app/v1/resource/tcnamespace/create.go
+++ b/service/controller/app/v1/resource/tcnamespace/create.go
@@ -27,16 +27,22 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	// Resource is used to bootstrap chart-operator in tenant clusters.
+	// So for other apps we can skip this step.
+	if key.AppName(cr) != key.ChartOperatorAppName {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no need to create namespace for %#q", key.AppName(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
 	if key.InCluster(cr) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q in %#q uses InCluster kubeconfig no need to create namespace", cr.Name, cr.Namespace))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}
 
-	// Resource is used to bootstrap chart-operator in tenant clusters.
-	// So for other apps we can skip this step.
-	if key.AppName(cr) != key.ChartOperatorAppName {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no need to create namespace for %#q", key.AppName(cr)))
+	if cc.Status.TenantCluster.IsUnavailable {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is unavailable")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}

--- a/service/controller/app/v1/resource/tiller/create.go
+++ b/service/controller/app/v1/resource/tiller/create.go
@@ -20,16 +20,22 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	// Resource is used to bootstrap chart-operator in tenant clusters.
+	// So for other apps we can skip this step.
+	if key.AppName(cr) != key.ChartOperatorAppName {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no need to install tiller for %#q", key.AppName(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
 	if key.InCluster(cr) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q in %#q uses InCluster kubeconfig no need to install tiller", cr.Name, cr.Namespace))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}
 
-	// Resource is used to bootstrap chart-operator in tenant clusters.
-	// So for other apps we can skip this step.
-	if key.AppName(cr) != key.ChartOperatorAppName {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no need to install tiller for %#q", key.AppName(cr)))
+	if cc.Status.TenantCluster.IsUnavailable {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is unavailable")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8970

There was some instability in `gauss` due to draughtsman secrets that stopped aws-operator being installed. 

But I also noticed that a kubeconfig secret was missing from an old tenant cluster. This is now handled and the resources are cancelled. 

```
E 02/26 12:46:35 /apis/application.giantswarm.io/v1alpha1/namespaces/p4qf4/apps/chart-operator failed processing event | operatorkit/controller/controller.go:529 | controller=app-operator | event=update | loop=4 | version=132969005
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/controller/controller.go:635:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/metricsresource/basic_resource.go:43:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/basic_resource.go:64:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/backoff/retry.go:23:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/operatorkit/resource/wrapper/retryresource/basic_resource.go:52:
	/go/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/clients/create.go:21:
	/go/src/github.com/giantswarm/app-operator/service/controller/app/v1/resource/clients/resource.go:105:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/kubeconfig/kubeconfig.go:57:
	/go/src/github.com/giantswarm/app-operator/vendor/github.com/giantswarm/kubeconfig/kubeconfig.go:130: Secret `p4qf4-kubeconfig` in Namespace `p4qf4`
	missing kube config error
```