### PR TITLE
Implement delete patch on update for configmaps and secrets

### DIFF
--- a/service/controller/app/v1/resource/configmap/delete.go
+++ b/service/controller/app/v1/resource/configmap/delete.go
@@ -59,3 +59,26 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 
 	return desiredConfigMap, nil
 }
+
+func (r *Resource) newDeleteChangeForUpdate(ctx context.Context, currentState, desiredState interface{}) (interface{}, error) {
+	currentConfigMap, err := toConfigMap(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredConfigMap, err := toConfigMap(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the configmap has to be deleted")
+
+	if !isEmpty(currentConfigMap) && isEmpty(desiredConfigMap) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the configmap has to be deleted")
+		return currentConfigMap, nil
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "the configmap does not have to be deleted")
+
+	return nil, nil
+}

--- a/service/controller/app/v1/resource/configmap/update.go
+++ b/service/controller/app/v1/resource/configmap/update.go
@@ -55,7 +55,7 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentConfigMap, de
 	patch := crud.NewPatch()
 	patch.SetCreateChange(create)
 	patch.SetUpdateChange(update)
-	patch.SetUpdateChange(delete)
+	patch.SetDeleteChange(delete)
 
 	return patch, nil
 }

--- a/service/controller/app/v1/resource/configmap/update.go
+++ b/service/controller/app/v1/resource/configmap/update.go
@@ -47,9 +47,15 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentConfigMap, de
 		return nil, microerror.Mask(err)
 	}
 
+	delete, err := r.newDeleteChangeForUpdate(ctx, currentConfigMap, desiredConfigMap)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	patch := crud.NewPatch()
 	patch.SetCreateChange(create)
 	patch.SetUpdateChange(update)
+	patch.SetUpdateChange(delete)
 
 	return patch, nil
 }

--- a/service/controller/app/v1/resource/secret/delete.go
+++ b/service/controller/app/v1/resource/secret/delete.go
@@ -59,3 +59,26 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 
 	return desiredSecret, nil
 }
+
+func (r *Resource) newDeleteChangeForUpdate(ctx context.Context, currentState, desiredState interface{}) (interface{}, error) {
+	currentSecret, err := toSecret(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	desiredSecret, err := toSecret(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the secret has to be deleted")
+
+	if !isEmpty(currentSecret) && isEmpty(desiredSecret) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the secret has to be deleted")
+		return currentSecret, nil
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "the secret does not have to be deleted")
+
+	return nil, nil
+}

--- a/service/controller/app/v1/resource/secret/update.go
+++ b/service/controller/app/v1/resource/secret/update.go
@@ -47,9 +47,15 @@ func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentSecret, desir
 		return nil, microerror.Mask(err)
 	}
 
+	delete, err := r.newDeleteChangeForUpdate(ctx, currentSecret, desiredSecret)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	patch := crud.NewPatch()
 	patch.SetCreateChange(create)
 	patch.SetUpdateChange(update)
+	patch.SetDeleteChange(delete)
 
 	return patch, nil
 }


### PR DESCRIPTION
```
 D 03/27 15:57:21 found 1 orphan secrets giantswarm.releases-kvm-unique-chart-secrets | chart-operator/service/collector/orphan_secret.go:94
```

Fix for orphan chart configmaps and secrets. If there was no resource then we cleared the app CR spec but didn't delete the configmap and secret.

In this case its because the release apps moved from the control-plane to releases catalog. But there are other edge cases that this will fix.
 