### PR TITLE
Fix e2e test

### DIFF
--- a/integration/test/app/basic/simple_test.go
+++ b/integration/test/app/basic/simple_test.go
@@ -51,7 +51,7 @@ func TestAppLifecycle(t *testing.T) {
 			Name:      key.TestAppReleaseName(),
 			Namespace: namespace,
 			Catalog:   testAppCatalogName,
-			Version:   "0.7.0",
+			Version:   "0.8.0",
 			Config: chartvalues.APIExtensionsAppE2EConfigAppConfig{
 				ConfigMap: chartvalues.APIExtensionsAppE2EConfigAppConfigConfigMap{
 					Name:      "test-app-values",
@@ -165,7 +165,7 @@ func TestAppLifecycle(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "checking tarball URL in chart spec")
 
-		tarballURL := "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.0.tgz"
+		tarballURL := "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.8.0.tgz"
 		chart, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(namespace).Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
@@ -183,7 +183,7 @@ func TestAppLifecycle(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart value for release %#q", key.CustomResourceReleaseName()))
 
-		sampleChart.App.Version = "0.7.1"
+		sampleChart.App.Version = "0.8.1"
 		chartValues, err = chartvalues.NewAPIExtensionsAppE2E(sampleChart)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
@@ -218,7 +218,7 @@ func TestAppLifecycle(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "checking tarball URL in chart spec")
 
-		err = config.Release.WaitForChartInfo(ctx, key.TestAppReleaseName(), "0.7.1")
+		err = config.Release.WaitForChartInfo(ctx, key.TestAppReleaseName(), "0.8.1")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -228,7 +228,7 @@ func TestAppLifecycle(t *testing.T) {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		tarballURL := "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.1.tgz"
+		tarballURL := "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.8.1.tgz"
 		if chart.Spec.TarballURL != tarballURL {
 			t.Fatalf("expected tarballURL: %#v got %#v", tarballURL, chart.Spec.TarballURL)
 		}

--- a/integration/test/app/kubeconfig/kubeconfig_test.go
+++ b/integration/test/app/kubeconfig/kubeconfig_test.go
@@ -46,7 +46,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 			Name:      key.TestAppReleaseName(),
 			Namespace: namespace,
 			Catalog:   testAppCatalogName,
-			Version:   "0.7.0",
+			Version:   "0.8.0",
 			Config: chartvalues.APIExtensionsAppE2EConfigAppConfig{
 				ConfigMap: chartvalues.APIExtensionsAppE2EConfigAppConfigConfigMap{
 					Name:      "test-app-values",
@@ -239,7 +239,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "checking tarball URL in chart spec")
 
-		tarballURL := "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.0.tgz"
+		tarballURL := "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.8.0.tgz"
 		chart, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(namespace).Get(key.TestAppReleaseName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
@@ -257,7 +257,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating chart value for release %#q", key.CustomResourceReleaseName()))
 
-		sampleChart.App.Version = "0.7.1"
+		sampleChart.App.Version = "0.8.1"
 		chartValues, err = chartvalues.NewAPIExtensionsAppE2E(sampleChart)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
@@ -292,7 +292,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "checking tarball URL in chart spec")
 
-		err = config.Release.WaitForChartInfo(ctx, key.TestAppReleaseName(), "0.7.1")
+		err = config.Release.WaitForChartInfo(ctx, key.TestAppReleaseName(), "0.8.1")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -302,7 +302,7 @@ func TestAppLifecycleUsingKubeconfig(t *testing.T) {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		tarballURL := "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.7.1.tgz"
+		tarballURL := "https://giantswarm.github.com/sample-catalog/kubernetes-test-app-chart-0.8.1.tgz"
 		if chart.Spec.TarballURL != tarballURL {
 			t.Fatalf("expected tarballURL: %#v got %#v", tarballURL, chart.Spec.TarballURL)
 		}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.

Failed on e2etest since new kind version had been introduced. 
```
2020-04-07T15:28:36.802548224Z stdout F {"caller":"github.com/giantswarm/chart-operator/service/controller/chart/v1/resource/release/create.go:102","controller":"chart-operator-chart","event":"update","function":"ApplyCreateChange","level":"debug","loop":"1","message":"helm release `kubernetes-test-app-chart` failed","object":"/apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/kubernetes-test-app-chart","resource":"releasev1","stack":{"annotation":"unable to build kubernetes objects from release manifest: error validating \"\": error validating data: ValidationError(ClusterRoleBinding.roleRef): unknown field \"labels\" in io.k8s.api.rbac.v1.RoleRef","kind":"unknown","stack":[{"file":"/go/pkg/mod/github.com/giantswarm/helmclient@v0.0.0-20200331110847-d697c5c4a0fb/install.go","line":48},{"file":"/go/pkg/mod/github.com/giantswarm/helmclient@v0.0.0-20200331110847-d697c5c4a0fb/install.go","line":22}]},"time":"2020-04-07T15:28:36.80235+00:00","version":"956"}
```

We would replace test app chart base version as `v0.8.0`