### PR TITLE
Process current CR for chart-operator bootstrapping

### DIFF
--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -5,7 +5,7 @@ package templates
 // ChartOperatorValues values required by chart-operator-chart.
 const ChartOperatorValues = `
 clusterDNSIP: 10.96.0.10
-e2e: true
+e2e: false
 externalDNSIP: 8.8.8.8
 image:
   registry: "quay.io"

--- a/service/controller/app/v1/resource/chartoperator/resource.go
+++ b/service/controller/app/v1/resource/chartoperator/resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
 	"github.com/spf13/afero"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,17 +94,7 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 		return microerror.Mask(err)
 	}
 
-	chartOperatorAppCR, err := r.getChartOperatorAppCR(ctx, cr.Namespace)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	appCatalogCR, err := r.getAppCatalogCR(ctx, chartOperatorAppCR)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	chartOperatorValues, err := r.mergeChartOperatorValues(ctx, chartOperatorAppCR, appCatalogCR)
+	chartOperatorValues, err := r.mergeChartOperatorValues(ctx, cr, cc.AppCatalog)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -113,7 +102,7 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 	// check app CR for chart-operator and fetching app-catalog name and version.
 	var tarballURL string
 	{
-		tarballURL, err = appcatalog.NewTarballURL(key.AppCatalogStorageURL(*appCatalogCR), release, key.Version(*chartOperatorAppCR))
+		tarballURL, err = appcatalog.NewTarballURL(key.AppCatalogStorageURL(cc.AppCatalog), key.AppName(cr), key.Version(cr))
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -181,17 +170,7 @@ func (r Resource) updateChartOperator(ctx context.Context, cr v1alpha1.App) erro
 		return microerror.Mask(err)
 	}
 
-	chartOperatorAppCR, err := r.getChartOperatorAppCR(ctx, cr.Namespace)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	appCatalogCR, err := r.getAppCatalogCR(ctx, chartOperatorAppCR)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	chartOperatorValues, err := r.mergeChartOperatorValues(ctx, chartOperatorAppCR, appCatalogCR)
+	chartOperatorValues, err := r.mergeChartOperatorValues(ctx, cr, cc.AppCatalog)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -199,7 +178,7 @@ func (r Resource) updateChartOperator(ctx context.Context, cr v1alpha1.App) erro
 	// check app CR for chart-operator and fetching app-catalog name and version.
 	var tarballURL string
 	{
-		tarballURL, err = appcatalog.NewTarballURL(key.AppCatalogStorageURL(*appCatalogCR), release, key.Version(*chartOperatorAppCR))
+		tarballURL, err = appcatalog.NewTarballURL(key.AppCatalogStorageURL(cc.AppCatalog), key.AppName(cr), key.Version(cr))
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -255,54 +234,10 @@ func (r Resource) updateChartOperator(ctx context.Context, cr v1alpha1.App) erro
 	return nil
 }
 
-func (r *Resource) getAppCatalogCR(ctx context.Context, chartOperatorAppCR *v1alpha1.App) (*v1alpha1.AppCatalog, error) {
-	var appCatalogCR *v1alpha1.AppCatalog
-	var err error
-	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "finding appCatalog CR")
-
-		catalogName := key.CatalogName(*chartOperatorAppCR)
-		appCatalogCR, err = r.g8sClient.ApplicationV1alpha1().AppCatalogs().Get(catalogName, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "can't find appCatalog CR")
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling the reconciliation")
-			reconciliationcanceledcontext.SetCanceled(ctx)
-			return nil, nil
-		} else if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", "found appCatalog CR")
-	}
-
-	return appCatalogCR, nil
-}
-
-func (r *Resource) getChartOperatorAppCR(ctx context.Context, namespace string) (*v1alpha1.App, error) {
-	var chartOperatorAppCR *v1alpha1.App
-	var err error
-	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "finding chart-operator app CR")
-
-		chartOperatorAppCR, err = r.g8sClient.ApplicationV1alpha1().Apps(namespace).Get(release, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "can't find chart-operator app CR")
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling the reconciliation")
-			reconciliationcanceledcontext.SetCanceled(ctx)
-			return nil, nil
-		} else if err != nil {
-			return nil, err
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", "found chart-operator app CR")
-	}
-	return chartOperatorAppCR, nil
-}
-
-func (r *Resource) mergeChartOperatorValues(ctx context.Context, cr *v1alpha1.App, catalog *v1alpha1.AppCatalog) ([]byte, error) {
+func (r *Resource) mergeChartOperatorValues(ctx context.Context, cr v1alpha1.App, catalog v1alpha1.AppCatalog) ([]byte, error) {
 	var chartOperatorValues []byte
 	{
-		values, err := r.values.MergeAll(ctx, *cr, *catalog)
+		values, err := r.values.MergeAll(ctx, cr, catalog)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7896

This is cleanup that got missed from a previous change. We only execute the chartoperator resource for its CRs. So we can process the current CR instead of fetching it again.

https://github.com/giantswarm/app-operator/blob/5fe0a86c388282d6b35f1d05c938f65bfeb1d6b6/service/controller/app/v1/resource/chartoperator/create.go#L26-L32
