### PR TITLE
Remove hardcoded release name from chartoperator resource

### DIFF
--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -5,7 +5,7 @@ package templates
 // ChartOperatorValues values required by chart-operator-chart.
 const ChartOperatorValues = `
 clusterDNSIP: 10.96.0.10
-e2e: true
+e2e: false
 externalDNSIP: 8.8.8.8
 image:
   registry: "quay.io"

--- a/service/controller/app/v1/resource/chartoperator/create.go
+++ b/service/controller/app/v1/resource/chartoperator/create.go
@@ -99,7 +99,7 @@ func (r Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		} else {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found release %#q", cr.Name))
 
-			releaseContent, err := cc.Clients.Helm.GetReleaseContent(ctx, release)
+			releaseContent, err := cc.Clients.Helm.GetReleaseContent(ctx, cr.Name)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/app/v1/resource/chartoperator/resource.go
+++ b/service/controller/app/v1/resource/chartoperator/resource.go
@@ -27,10 +27,6 @@ const (
 	Name = "chartoperatorv1"
 )
 
-const (
-	release = "chart-operator"
-)
-
 // Config represents the configuration used to create a new clients resource.
 type Config struct {
 	// Dependencies.

--- a/service/controller/app/v1/resource/chartoperator/resource.go
+++ b/service/controller/app/v1/resource/chartoperator/resource.go
@@ -29,8 +29,7 @@ const (
 )
 
 const (
-	namespace = "giantswarm"
-	release   = "chart-operator"
+	release = "chart-operator"
 )
 
 // Config represents the configuration used to create a new clients resource.
@@ -135,7 +134,7 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 	}
 
 	{
-		err = cc.Clients.Helm.InstallReleaseFromTarball(ctx, tarballPath, namespace, helm.ReleaseName(release), helm.ValueOverrides(chartOperatorValues))
+		err = cc.Clients.Helm.InstallReleaseFromTarball(ctx, tarballPath, key.Namespace(cr), helm.ReleaseName(cr.Name), helm.ValueOverrides(chartOperatorValues))
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -145,10 +144,10 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 		// We wait for the chart-operator deployment to be ready so the
 		// chart CRD is installed. This allows the chart
 		// resource to create CRs in the same reconcilation loop.
-		r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for ready chart-operator deployment")
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for ready %#q deployment", cr.Name))
 
 		o := func() error {
-			err := r.checkDeploymentReady(ctx, cc.Clients.K8s)
+			err := r.checkDeploymentReady(ctx, cc.Clients.K8s, cr)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -161,7 +160,7 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 		// reconciliation loop.
 		b := backoff.NewConstant(20*time.Second, 5*time.Second)
 		n := func(err error, delay time.Duration) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q deployment is not ready retrying in %s", release, delay), "stack", fmt.Sprintf("%#v", err))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q deployment is not ready retrying in %s", cr.Name, delay), "stack", fmt.Sprintf("%#v", err))
 		}
 
 		err = backoff.RetryNotify(o, b, n)
@@ -169,7 +168,7 @@ func (r Resource) installChartOperator(ctx context.Context, cr v1alpha1.App) err
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "chart-operator deployment is ready")
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q deployment is ready", cr.Name))
 	}
 
 	return nil
@@ -221,17 +220,17 @@ func (r Resource) updateChartOperator(ctx context.Context, cr v1alpha1.App) erro
 	}
 
 	{
-		err = cc.Clients.Helm.UpdateReleaseFromTarball(ctx, release, tarballPath, helm.UpdateValueOverrides(chartOperatorValues), helm.UpgradeForce(true))
+		err = cc.Clients.Helm.UpdateReleaseFromTarball(ctx, cr.Name, tarballPath, helm.UpdateValueOverrides(chartOperatorValues), helm.UpgradeForce(true))
 		if err != nil {
 			return microerror.Mask(err)
 		}
 	}
 
 	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for ready chart-operator deployment")
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for ready %#q deployment", cr.Name))
 
 		o := func() error {
-			err := r.checkDeploymentReady(ctx, cc.Clients.K8s)
+			err := r.checkDeploymentReady(ctx, cc.Clients.K8s, cr)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -241,7 +240,7 @@ func (r Resource) updateChartOperator(ctx context.Context, cr v1alpha1.App) erro
 
 		b := backoff.NewConstant(20*time.Second, 10*time.Second)
 		n := func(err error, delay time.Duration) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q deployment is not ready retrying in %s", release, delay), "stack", fmt.Sprintf("%#v", err))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q deployment is not ready retrying in %s", cr.Name, delay), "stack", fmt.Sprintf("%#v", err))
 		}
 
 		err = backoff.RetryNotify(o, b, n)
@@ -249,7 +248,7 @@ func (r Resource) updateChartOperator(ctx context.Context, cr v1alpha1.App) erro
 			return microerror.Mask(err)
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "chart-operator deployment is ready")
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q deployment is ready", cr.Name))
 	}
 
 	return nil
@@ -317,16 +316,17 @@ func (r *Resource) mergeChartOperatorValues(ctx context.Context, cr *v1alpha1.Ap
 
 // checkDeploymentReady checks for the specified deployment that the number of
 // ready replicas matches the desired state.
-func (r *Resource) checkDeploymentReady(ctx context.Context, k8sClient kubernetes.Interface) error {
-	deploy, err := k8sClient.AppsV1().Deployments(namespace).Get(release, metav1.GetOptions{})
+func (r *Resource) checkDeploymentReady(ctx context.Context, k8sClient kubernetes.Interface, cr v1alpha1.App) error {
+	namespace := key.Namespace(cr)
+	deploy, err := k8sClient.AppsV1().Deployments(namespace).Get(cr.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		return microerror.Maskf(notReadyError, "deployment %#q not found", release)
+		return microerror.Maskf(notReadyError, "deployment %#q not found", cr.Name)
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
 
 	if deploy.Status.ReadyReplicas != *deploy.Spec.Replicas {
-		return microerror.Maskf(notReadyError, "deployment %#q want %d replicas %d ready", release, *deploy.Spec.Replicas, deploy.Status.ReadyReplicas)
+		return microerror.Maskf(notReadyError, "deployment %#q want %d replicas %d ready", cr.Name, *deploy.Spec.Replicas, deploy.Status.ReadyReplicas)
 	}
 
 	// Deployment is ready.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7896

This removed the hardcoded release name and namespace. This is needed because in control planes the chart-operator CR will be called `chart-operator-unique`.
