### PR TITLE
avoid migrating if no tenant avaialble

### DIFF
--- a/service/controller/app/resource/releasemigration/create.go
+++ b/service/controller/app/resource/releasemigration/create.go
@@ -30,6 +30,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	if cc.Status.TenantCluster.IsUnavailable {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is unavailable")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
 	//TODO: Remove this statement when we need to test on control planes.
 	if key.InCluster(cr) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q uses InCluster kubeconfig no need to migrate releases", key.AppName(cr)))


### PR DESCRIPTION
Canceling migration in the case of tenant is not available. 