### PR TITLE
migrating only in case of chart-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/giantswarm/app-operator
 go 1.13
 
 require (
+	github.com/Masterminds/semver/v3 v3.0.3
 	github.com/giantswarm/apiextensions v0.2.0
 	github.com/giantswarm/appcatalog v0.2.0
 	github.com/giantswarm/apprclient v0.2.0

--- a/integration/test/app/kubeconfig/kubeconfig_test.go
+++ b/integration/test/app/kubeconfig/kubeconfig_test.go
@@ -190,7 +190,7 @@ func TestAppWithKubeconfig(t *testing.T) {
 
 		// TODO: Removing hardcoding once there is a chart-operator release
 		// with Helm 3 support in the default catalog.
-		tag := "0.13.0-cabc326450846735cd579454be8c945465a9175e"
+		tag := "0.12.1-cbacf365e9633281909eca61992c1fcd99927396"
 
 		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(namespace).Create(&v1alpha1.App{
 			ObjectMeta: metav1.ObjectMeta{

--- a/service/controller/app/resource/releasemigration/create.go
+++ b/service/controller/app/resource/releasemigration/create.go
@@ -62,12 +62,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
-	content, err := cc.Clients.Helm.GetReleaseContent(ctx, key.Namespace(cr), key.ReleaseName(cr))
+	chart, err := cc.Clients.K8s.G8sClient().ApplicationV1alpha1().Charts(r.chartNamespace).Get(cr.GetName(), metav1.GetOptions{})
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	if content.Version != key.Version(cr) || content.Status != "DEPLOYED" {
+	if chart.Status.Version != key.Version(cr) || chart.Status.Release.Status != "DEPLOYED" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q is not deployed yet", key.AppName(cr)))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil

--- a/service/controller/app/resource/releasemigration/create.go
+++ b/service/controller/app/resource/releasemigration/create.go
@@ -44,9 +44,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
-	// Resource is used to migrating all charts. it's too noisy if it works on every reconciliation.
+	// Resource is used to migrating Helm 2 release into Helm 3 in case of chart-operator app reconciliation.
+	// So for other apps we can skip this step.
 	if key.AppName(cr) != key.ChartOperatorAppName {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no need to migrate %#q", key.AppName(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no need to migrating Helm release for %#q", key.AppName(cr)))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}
@@ -57,7 +58,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if v.Major() < 1 {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q's current version %#q is not greater than 1.0.0.", key.AppName(cr), key.Version(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q, version %#q is using Helm 2. we don't need to trigger Helm 3 migration.", key.AppName(cr), key.Version(cr)))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}

--- a/service/controller/app/resource/releasemigration/create.go
+++ b/service/controller/app/resource/releasemigration/create.go
@@ -53,7 +53,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if cr.Status.AppVersion == "" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q is not installed yet", key.AppName(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q is not installed yet", key.AppName(cr)))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}
@@ -64,13 +64,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if v.Major() < 1 {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("chart %#q, version %#q is using Helm 2. we don't need to trigger Helm 3 migration.", key.AppName(cr), key.Version(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q with appVersion %#q is using Helm 2. we don't need to trigger Helm 3 migration.", key.AppName(cr), cr.Status.AppVersion))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}
 
 	if cr.Status.Release.Status != "DEPLOYED" {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%#q is not deployed yet", key.AppName(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q is not deployed yet", key.AppName(cr)))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil
 	}

--- a/service/controller/app/resource/releasemigration/resource.go
+++ b/service/controller/app/resource/releasemigration/resource.go
@@ -26,11 +26,17 @@ const (
 type Config struct {
 	// Dependencies.
 	Logger micrologger.Logger
+
+	// Settings.
+	ChartNamespace string
 }
 
 type Resource struct {
 	// Dependencies.
 	logger micrologger.Logger
+
+	// Settings.
+	chartNamespace string
 }
 
 func New(config Config) (*Resource, error) {
@@ -38,8 +44,14 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
+	if config.ChartNamespace == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ChartNamespace must not be empty", config)
+	}
+
 	r := &Resource{
 		logger: config.Logger,
+
+		chartNamespace: config.ChartNamespace,
 	}
 
 	return r, nil

--- a/service/controller/app/resource_set.go
+++ b/service/controller/app/resource_set.go
@@ -176,6 +176,8 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	{
 		c := releasemigration.Config{
 			Logger: config.Logger,
+
+			ChartNamespace: config.ChartNamespace,
 		}
 
 		releaseMigrationResource, err = releasemigration.New(c)


### PR DESCRIPTION
`releasemigration` works in case of below; 
1. When its chart-operator app CR reconciliation
2. if the `appVersion` is greater or equal than 1
3. When the latest chart-operator is up and running in TC. 
