### PR TITLE
check status version with spec version before move on

### DIFF
--- a/service/controller/app/resource/releasemigration/create.go
+++ b/service/controller/app/resource/releasemigration/create.go
@@ -53,6 +53,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
+	if key.Version(cr) != cr.Status.Version {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q is not reconciled to the latest desired status yet", key.AppName(cr)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
 	if cr.Status.AppVersion == "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q is not installed yet", key.AppName(cr)))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")


### PR DESCRIPTION
Checking `.spec.version` with `.status.version` before we move on to release migration. 