### PR TITLE
Helm3 major version label

### DIFF
--- a/integration/test/app/basic/simple_test.go
+++ b/integration/test/app/basic/simple_test.go
@@ -102,6 +102,8 @@ func TestAppLifecycle(t *testing.T) {
 				Name: key.DefaultCatalogName(),
 				Labels: map[string]string{
 					label.AppOperatorVersion: key.AppOperatorVersion(),
+					// Helm major version is 3 for the master branch.
+					label.HelmMajorVersion: "3",
 				},
 			},
 			Spec: v1alpha1.AppCatalogSpec{

--- a/integration/test/app/basic/simple_test.go
+++ b/integration/test/app/basic/simple_test.go
@@ -102,8 +102,6 @@ func TestAppLifecycle(t *testing.T) {
 				Name: key.DefaultCatalogName(),
 				Labels: map[string]string{
 					label.AppOperatorVersion: key.AppOperatorVersion(),
-					// Helm major version is 3 for the master branch.
-					label.HelmMajorVersion: "3",
 				},
 			},
 			Spec: v1alpha1.AppCatalogSpec{

--- a/integration/test/app/kubeconfig/kubeconfig_test.go
+++ b/integration/test/app/kubeconfig/kubeconfig_test.go
@@ -151,8 +151,6 @@ func TestAppWithKubeconfig(t *testing.T) {
 				Namespace: namespace,
 				Labels: map[string]string{
 					label.AppOperatorVersion: key.AppOperatorVersion(),
-					// Helm major version is 3 for the master branch.
-					label.HelmMajorVersion: "3",
 				},
 			},
 			Spec: v1alpha1.AppSpec{
@@ -200,6 +198,8 @@ func TestAppWithKubeconfig(t *testing.T) {
 				Namespace: namespace,
 				Labels: map[string]string{
 					label.AppOperatorVersion: key.AppOperatorVersion(),
+					// Helm major version is 3 for the master branch.
+					label.HelmMajorVersion: "3",
 				},
 			},
 			Spec: v1alpha1.AppSpec{

--- a/integration/test/app/kubeconfig/kubeconfig_test.go
+++ b/integration/test/app/kubeconfig/kubeconfig_test.go
@@ -151,6 +151,8 @@ func TestAppWithKubeconfig(t *testing.T) {
 				Namespace: namespace,
 				Labels: map[string]string{
 					label.AppOperatorVersion: key.AppOperatorVersion(),
+					// Helm major version is 3 for the master branch.
+					label.HelmMajorVersion: "3",
 				},
 			},
 			Spec: v1alpha1.AppSpec{

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -13,6 +13,10 @@ const (
 	// Cluster label is a new style label for ClusterID
 	Cluster = "giantswarm.io/cluster"
 
+	// HelmMajorVersion is set for chart-operator app CRs and controls whether
+	// we bootstrap chart-operator in tenant clusters.
+	HelmMajorVersion = "app-operator.giantswarm.io/helm-major-version"
+
 	// Organization label denotes guest cluster's organization ID as displayed
 	// in the front-end.
 	Organization = "giantswarm.io/organization"

--- a/service/controller/app/key/key.go
+++ b/service/controller/app/key/key.go
@@ -146,6 +146,10 @@ func IsDeleted(customResource v1alpha1.App) bool {
 	return customResource.DeletionTimestamp != nil
 }
 
+func HelmMajorVersion(customResource v1alpha1.App) string {
+	return customResource.GetLabels()[label.HelmMajorVersion]
+}
+
 func KubeConfigFinalizer(customResource v1alpha1.App) string {
 	return fmt.Sprintf("app-operator.giantswarm.io/app-%s", customResource.GetName())
 }

--- a/service/controller/app/resource/chartoperator/create.go
+++ b/service/controller/app/resource/chartoperator/create.go
@@ -39,6 +39,14 @@ func (r Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
+	// We only bootstrap chart-operator if the app CR uses Helm 3.
+	// Helm 2 is managed by the thiccc deployment of app-operator.
+	if key.HelmMajorVersion(cr) != "3" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q not using helm 3", cr.Name))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding %#q deployment", cr.Name))
 

--- a/service/controller/app/resource/tcnamespace/create.go
+++ b/service/controller/app/resource/tcnamespace/create.go
@@ -41,6 +41,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
+	// We only create the tenant namespace if the chart-operator app uses Helm 3.
+	// Helm 2 is managed by the thiccc deployment of app-operator.
+	if key.HelmMajorVersion(cr) != "3" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q not using helm 3", cr.Name))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return nil
+	}
+
 	if cc.Status.TenantCluster.IsUnavailable {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is unavailable")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")


### PR DESCRIPTION
We will add a new label `app-operator.giantswarm.io/helm-major-version="3"` to chart-operator app CRs in cluster-operator if chart-operator is version 1.X.

In the thiccc pod we use a label selector to exclude these CRs. The thiccc pod is only used to bootstrap chart-operator.

For Helm 3 we only execute the tcnamespace and chartoperator resources if this label is present.