### PR TITLE
Blocking app collection pushing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ workflows:
             tags:
               only: /^v.*/
 
+#      TODO: Uncomment it after we deployed helm 3 supported app-operator into all installations.
 #      # deploy to aws installations (only tags)
 #      - architect/push-to-app-collection:
 #          context: "architect"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,53 +52,53 @@ workflows:
             tags:
               only: /^v.*/
 
-      # deploy to aws installations (only tags)
-      - architect/push-to-app-collection:
-          context: "architect"
-          name: push-app-operator-to-aws-app-collection
-          app_name: "app-operator"
-          app_collection_repo: "aws-app-collection"
-          disable_force_upgrade: true
-          unique: "true"
-          requires:
-            - push-app-operator-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      # deploy to azure installations (only tags)
-      - architect/push-to-app-collection:
-          context: "architect"
-          name: push-app-operator-to-azure-app-collection
-          app_name: "app-operator"
-          app_collection_repo: "azure-app-collection"
-          disable_force_upgrade: true
-          unique: "true"
-          requires:
-            - push-app-operator-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      # deploy to kvm installations (only tags)
-      - architect/push-to-app-collection:
-          context: "architect"
-          name: push-app-operator-to-kvm-app-collection
-          app_name: "app-operator"
-          app_collection_repo: "kvm-app-collection"
-          disable_force_upgrade: true
-          unique: "true"
-          requires:
-            - push-app-operator-to-control-plane-app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+#      # deploy to aws installations (only tags)
+#      - architect/push-to-app-collection:
+#          context: "architect"
+#          name: push-app-operator-to-aws-app-collection
+#          app_name: "app-operator"
+#          app_collection_repo: "aws-app-collection"
+#          disable_force_upgrade: true
+#          unique: "true"
+#          requires:
+#            - push-app-operator-to-control-plane-app-catalog
+#          filters:
+#            branches:
+#              ignore: /.*/
+#            tags:
+#              only: /^v.*/
+#
+#      # deploy to azure installations (only tags)
+#      - architect/push-to-app-collection:
+#          context: "architect"
+#          name: push-app-operator-to-azure-app-collection
+#          app_name: "app-operator"
+#          app_collection_repo: "azure-app-collection"
+#          disable_force_upgrade: true
+#          unique: "true"
+#          requires:
+#            - push-app-operator-to-control-plane-app-catalog
+#          filters:
+#            branches:
+#              ignore: /.*/
+#            tags:
+#              only: /^v.*/
+#
+#      # deploy to kvm installations (only tags)
+#      - architect/push-to-app-collection:
+#          context: "architect"
+#          name: push-app-operator-to-kvm-app-collection
+#          app_name: "app-operator"
+#          app_collection_repo: "kvm-app-collection"
+#          disable_force_upgrade: true
+#          unique: "true"
+#          requires:
+#            - push-app-operator-to-control-plane-app-catalog
+#          filters:
+#            branches:
+#              ignore: /.*/
+#            tags:
+#              only: /^v.*/
 
       - architect/integration-test:
           name: basic-integration-test


### PR DESCRIPTION
Blocking app collection pushing until we successfully deployed helm 3 supported version into all installations. 