### PR TITLE
fix values type for helm-2to3-migration

### DIFF
--- a/service/controller/app/resource/releasemigration/resource.go
+++ b/service/controller/app/resource/releasemigration/resource.go
@@ -146,11 +146,11 @@ func (r *Resource) ensureReleasesMigrated(ctx context.Context, k8sClient k8sclie
 			}
 
 			values := map[string]interface{}{
-				"image": map[string]string{
+				"image": map[string]interface{}{
 					"registry": r.imageRegistry,
 				},
 				"releases": releases,
-				"tiller": map[string]string{
+				"tiller": map[string]interface{}{
 					"namespace": tillerNamespace,
 				},
 			}


### PR DESCRIPTION
Fixing wrong value types on `releasemigration`. it breaks the type conversion in `helm` package.