### PR TITLE
Checking deployment image & status rather than helm status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## Unreleased
 
+### Changed
+
+- Checking chart-operator deployment status before initiate helm 3 migration.
+
 ## [v1.1.3] 2020-05-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Checking chart-operator deployment status before initiate helm 3 migration.
+- Check chart-operator deployment status before initiating helm 3 migration.
 
 ## [v1.1.3] 2020-05-26
 

--- a/service/controller/app/resource/releasemigration/create.go
+++ b/service/controller/app/resource/releasemigration/create.go
@@ -51,6 +51,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
+	if cr.Status.AppVersion == "" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q is not installed yet", key.AppName(cr)))
+	}
+
 	v, err := semver.NewVersion(cr.Status.AppVersion)
 	if err != nil {
 		return microerror.Mask(err)


### PR DESCRIPTION
When chart-operator 1.0.x deployed into clusters, it could not report its status back to chart-operator chart CRs since it could only look into the helm 3 release. At that point, the migration from helm 2 is not even starting. So before we start the migration, we need to check the version chart-operator containers and its deployment status (ReadyReplica), rather than helm status.

## Checklist

- [x] Update changelog in CHANGELOG.md.