### PR TITLE
readyReplica should be same as zero when it's not ready

### DIFF
--- a/service/controller/app/resource/releasemigration/create.go
+++ b/service/controller/app/resource/releasemigration/create.go
@@ -86,7 +86,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
-	if deploy.Status.ReadyReplicas > 0 {
+	if deploy.Status.ReadyReplicas == 0 {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("app %#q is not deployed yet", key.AppName(cr)))
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil


### PR DESCRIPTION
Wrong if statement checking. 🤦 

I should check `readyReplicas` same as 0 to cancel migration.  