### PR TITLE
Process app CRs with both version 0.0.0 and 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## Unreleased
 
+## [v1.0.5] 2020-06-03
+
+### Changed
+
+- Reconcile app CRs with both versions 1.0.0 and 0.0.0. This will be removed
+later.
+
 ## [v1.0.4] 2020-06-01
+
+### Changed
 
 - Reconcile different app CR versions for tenant and control planes.
 
@@ -29,8 +38,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Flattening operator release structure.
 
-[Unreleased]: https://github.com/giantswarm/app-operator/compare/v1.0.4..HEAD
+[Unreleased]: https://github.com/giantswarm/app-operator/compare/v1.0.5..HEAD
 
+[1.0.5]: https://github.com/giantswarm/app-operator/compare/v1.0.4..v1.0.5
 [1.0.4]: https://github.com/giantswarm/app-operator/compare/v1.0.3..v1.0.4
 [1.0.3]: https://github.com/giantswarm/app-operator/compare/v1.0.2..v1.0.3
 [1.0.2]: https://github.com/giantswarm/app-operator/compare/v1.0.1..v1.0.2

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "app-operator"
 	source      = "https://github.com/giantswarm/app-operator"
-	version     = "1.0.4"
+	version     = "1.0.5"
 )
 
 // AppControlPlaneVersion is always 0.0.0 for control plane app CRs. These CRs

--- a/service/controller/app/resource_set.go
+++ b/service/controller/app/resource_set.go
@@ -277,15 +277,23 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		// When app-operator is deployed as a unique app it only processes
 		// control plane app CRs. These CRs always have the version label
 		// app-operator.giantswarm.io/version: 0.0.0
-		if config.UniqueApp {
-			return key.VersionLabel(cr) == project.AppControlPlaneVersion()
-		}
+		//if config.UniqueApp {
+		//	return key.VersionLabel(cr) == project.AppControlPlaneVersion()
+		//}
 
 		// Currently tenant cluster app CRs always have the version label
 		// app-operator.giantswarm.io/verson: 1.0.0
 		// This hardcoding will be removed in a future release and we will then
 		// use project.Version().
-		return key.VersionLabel(cr) == project.AppTenantVersion()
+		//return key.VersionLabel(cr) == project.AppTenantVersion()
+
+		// TODO: Enable logic above once separate app-operator instances for
+		// tenant and control planes are re-enabled.
+		if key.VersionLabel(cr) == project.AppControlPlaneVersion() || key.VersionLabel(cr) == project.AppTenantVersion() {
+			return true
+		}
+
+		return false
 	}
 
 	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {


### PR DESCRIPTION
This is so we don't need to revert the opsctl and architect changes. It will be removed in 1.0.6 when we run separate app-operator instances again.

## Checklist

- [x] Update changelog in CHANGELOG.md.