### PR TITLE
Label selector for unique

### DIFF
--- a/service/controller/app/app.go
+++ b/service/controller/app/app.go
@@ -79,7 +79,7 @@ func NewApp(config Config) (*App, error) {
 			ResourceSets: []*controller.ResourceSet{
 				resourceSetV1,
 			},
-			Selector: key.AppLabelSelector(config.UniqueApp),
+			Selector: key.AppVersionSelector(config.UniqueApp),
 			NewRuntimeObjectFunc: func() runtime.Object {
 				return new(v1alpha1.App)
 			},

--- a/service/controller/app/app.go
+++ b/service/controller/app/app.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/giantswarm/app-operator/pkg/project"
+	"github.com/giantswarm/app-operator/service/controller/app/key"
 )
 
 type Config struct {
@@ -78,6 +79,7 @@ func NewApp(config Config) (*App, error) {
 			ResourceSets: []*controller.ResourceSet{
 				resourceSetV1,
 			},
+			Selector: key.AppLabelSelector(config.UniqueApp),
 			NewRuntimeObjectFunc: func() runtime.Object {
 				return new(v1alpha1.App)
 			},

--- a/service/controller/app/key/key.go
+++ b/service/controller/app/key/key.go
@@ -164,7 +164,7 @@ func KubecConfigSecretNamespace(customResource v1alpha1.App) string {
 	return customResource.Spec.KubeConfig.Secret.Namespace
 }
 
-func AppLabelSelector(unique bool) labels.Selector {
+func AppVersionSelector(unique bool) labels.Selector {
 	var version string
 
 	// Currently tenant cluster app CRs always have the version label
@@ -178,7 +178,6 @@ func AppLabelSelector(unique bool) labels.Selector {
 		// app-operator.giantswarm.io/version: 0.0.0
 		version = project.AppControlPlaneVersion()
 	}
-	// Selector to check if "app=chart-operator" and if helm-major-version is not belonging to 3.
 	s := fmt.Sprintf("%s=%s", label.AppOperatorVersion, version)
 
 	selector, err := labels.Parse(s)

--- a/service/controller/app/key/key.go
+++ b/service/controller/app/key/key.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/giantswarm/app-operator/pkg/annotation"
 	"github.com/giantswarm/app-operator/pkg/label"
+	"github.com/giantswarm/app-operator/pkg/project"
 )
 
 const (
@@ -160,6 +162,31 @@ func KubecConfigSecretName(customResource v1alpha1.App) string {
 
 func KubecConfigSecretNamespace(customResource v1alpha1.App) string {
 	return customResource.Spec.KubeConfig.Secret.Namespace
+}
+
+func AppLabelSelector(unique bool) labels.Selector {
+	var version string
+
+	// Currently tenant cluster app CRs always have the version label
+	// app-operator.giantswarm.io/verson: 1.0.0
+	// This hardcoding will be removed in a future release and we will then
+	// use project.Version().
+	version = project.AppTenantVersion()
+	if unique {
+		// When app-operator is deployed as a unique app it only processes
+		// control plane app CRs. These CRs always have the version label
+		// app-operator.giantswarm.io/version: 0.0.0
+		version = project.AppControlPlaneVersion()
+	}
+	// Selector to check if "app=chart-operator" and if helm-major-version is not belonging to 3.
+	s := fmt.Sprintf("%s=%s", label.AppOperatorVersion, version)
+
+	selector, err := labels.Parse(s)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse selector %#q with error %#q", s, err))
+	}
+
+	return selector
 }
 
 func Namespace(customResource v1alpha1.App) string {

--- a/service/controller/app/resource_set.go
+++ b/service/controller/app/resource_set.go
@@ -14,9 +14,7 @@ import (
 	"github.com/giantswarm/operatorkit/resource/wrapper/retryresource"
 	"github.com/spf13/afero"
 
-	"github.com/giantswarm/app-operator/pkg/project"
 	"github.com/giantswarm/app-operator/service/controller/app/controllercontext"
-	"github.com/giantswarm/app-operator/service/controller/app/key"
 	"github.com/giantswarm/app-operator/service/controller/app/resource/appcatalog"
 	"github.com/giantswarm/app-operator/service/controller/app/resource/appnamespace"
 	"github.com/giantswarm/app-operator/service/controller/app/resource/chart"
@@ -278,26 +276,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
-	handlesFunc := func(obj interface{}) bool {
-		cr, err := key.ToCustomResource(obj)
-		if err != nil {
-			return false
-		}
-
-		// When app-operator is deployed as a unique app it only processes
-		// control plane app CRs. These CRs always have the version label
-		// app-operator.giantswarm.io/version: 0.0.0
-		if config.UniqueApp {
-			return key.VersionLabel(cr) == project.AppControlPlaneVersion()
-		}
-
-		// Currently tenant cluster app CRs always have the version label
-		// app-operator.giantswarm.io/verson: 1.0.0
-		// This hardcoding will be removed in a future release and we will then
-		// use project.Version().
-		return key.VersionLabel(cr) == project.AppTenantVersion()
-	}
-
 	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
 		cc := controllercontext.Context{}
 		ctx = controllercontext.NewContext(ctx, cc)
@@ -308,7 +286,6 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 	var resourceSet *controller.ResourceSet
 	{
 		c := controller.ResourceSetConfig{
-			Handles:   handlesFunc,
 			InitCtx:   initCtxFunc,
 			Logger:    config.Logger,
 			Resources: resources,


### PR DESCRIPTION
With lableSelector in app-operator controller, We don't need to check the labels from resource_set anymore, and that's good for logging and reconciliation timing. 

logs > 
```
D 06/05 09:01:32 /apis/application.giantswarm.io/v1alpha1/namespaces/54naz/apps/node-exporter canceling reconciliation | operatorkit/controller/controller.go:464 | controller=app-operator | event=update | loop=289 | version=403269248
D 06/05 09:01:32 /apis/application.giantswarm.io/v1alpha1/namespaces/54naz/apps/node-exporter reconciled object | operatorkit/controller/controller.go:446 | controller=app-operator | event=update | loop=289 | version=403269248
D 06/05 09:01:32 /apis/application.giantswarm.io/v1alpha1/namespaces/w8g2o/apps/node-exporter reconciling object | operatorkit/controller/controller.go:444 | controller=app-operator | event=update | loop=290 | version=403269254
D 06/05 09:01:32 /apis/application.giantswarm.io/v1alpha1/namespaces/w8g2o/apps/node-exporter finding resource set | operatorkit/controller/controller.go:459 | controller=app-operator | event=update | loop=290 | version=403269254
D 06/05 09:01:32 /apis/application.giantswarm.io/v1alpha1/namespaces/w8g2o/apps/node-exporter did not find resource set | operatorkit/controller/controller.go:463 | controller=app-operator | event=update | loop=290 | version=403269254
D 06/05 09:01:32 /apis/application.giantswarm.io/v1alpha1/namespaces/w8g2o/apps/node-exporter canceling reconciliation | operatorkit/controller/controller.go:464 | controller=app-operator | event=update | loop=290 | version=403269254
D 06/05 09:01:32 /apis/application.giantswarm.io/v1alpha1/namespaces/w8g2o/apps/node-exporter reconciled object | operatorkit/controller/controller.go:446 | controller=app-operator | event=update | loop=290 | version=403269254
```

## Checklist

- [ ] Update changelog in CHANGELOG.md.