### PR TITLE
Using .spec.version in collector

### DIFF
--- a/service/collector/app_resource.go
+++ b/service/collector/app_resource.go
@@ -134,6 +134,7 @@ func (c *AppResource) collectAppStatus(ctx context.Context, ch chan<- prometheus
 			app.Namespace,
 			app.Status.Release.Status,
 			team,
+			// Getting version from spec, not status since the version in the spec is the desired version.
 			app.Spec.Version,
 		)
 

--- a/service/collector/app_resource.go
+++ b/service/collector/app_resource.go
@@ -134,7 +134,7 @@ func (c *AppResource) collectAppStatus(ctx context.Context, ch chan<- prometheus
 			app.Namespace,
 			app.Status.Release.Status,
 			team,
-			app.Status.Version,
+			app.Spec.Version,
 		)
 
 		if !key.IsCordoned(app) {


### PR DESCRIPTION
When app-operator failed to install `g8s-grafana` 1.2.0 version, operator reports in a collector as below. 
```
:fire: 10.0.134.87:8000: Control Plane App g8s-grafana-unique, version 1.1.0 is  not installed.
```
The version in `1.1.0` is actually the version we already installed. We need to change it to 1.2.0 as the desired version.  