### PR TITLE
Using selectors inside collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Delete helm-2to3-migration job after migration is finished.
 - Sending metrics with app CR's version in the spec.
-- Only send metrics from app CRs that reconciled from the controller. 
+- Only emit metrics for app CRs reconciled by this instance of the operator.
 
 ## [v1.1.5] 2020-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Delete helm-2to3-migration job after migration is finished.
 - Sending metrics with app CR's version in the spec.
+- Only send metrics from app CRs that reconciled from the controller. 
 
 ## [v1.1.5] 2020-06-16
 

--- a/service/collector/app_resource.go
+++ b/service/collector/app_resource.go
@@ -121,6 +121,7 @@ func (c *AppResource) collectAppStatus(ctx context.Context, ch chan<- prometheus
 	options := metav1.ListOptions{
 		LabelSelector: key.AppVersionSelector(c.uniqueApp).String(),
 	}
+
 	r, err := c.g8sClient.ApplicationV1alpha1().Apps("").List(options)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/collector/app_resource.go
+++ b/service/collector/app_resource.go
@@ -49,6 +49,7 @@ type AppResourceConfig struct {
 
 	AppTeamMapping map[string]string
 	DefaultTeam    string
+	UniqueApp      bool
 }
 
 // AppResource is the main struct for this collector.
@@ -59,6 +60,7 @@ type AppResource struct {
 
 	appTeamMapping map[string]string
 	defaultTeam    string
+	uniqueApp      bool
 }
 
 // NewAppResource creates a new AppResource metrics collector
@@ -87,6 +89,7 @@ func NewAppResource(config AppResourceConfig) (*AppResource, error) {
 
 		appTeamMapping: config.AppTeamMapping,
 		defaultTeam:    config.DefaultTeam,
+		uniqueApp:      config.UniqueApp,
 	}
 
 	return c, nil
@@ -115,7 +118,10 @@ func (c *AppResource) Describe(ch chan<- *prometheus.Desc) error {
 }
 
 func (c *AppResource) collectAppStatus(ctx context.Context, ch chan<- prometheus.Metric) error {
-	r, err := c.g8sClient.ApplicationV1alpha1().Apps("").List(metav1.ListOptions{})
+	options := metav1.ListOptions{
+		LabelSelector: key.AppVersionSelector(c.uniqueApp).String(),
+	}
+	r, err := c.g8sClient.ApplicationV1alpha1().Apps("").List(options)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -13,6 +13,7 @@ type SetConfig struct {
 
 	AppTeamMapping map[string]string
 	DefaultTeam    string
+	UniqueApp      bool
 }
 
 // Set is basically only a wrapper for the operator's collector implementations.
@@ -41,6 +42,7 @@ func NewSet(config SetConfig) (*Set, error) {
 
 			AppTeamMapping: config.AppTeamMapping,
 			DefaultTeam:    config.DefaultTeam,
+			UniqueApp:      config.UniqueApp,
 		}
 
 		appOperatorCollector, err = NewAppResource(c)

--- a/service/service.go
+++ b/service/service.go
@@ -149,6 +149,7 @@ func New(config Config) (*Service, error) {
 
 			AppTeamMapping: appTeamMapping,
 			DefaultTeam:    config.Viper.GetString(config.Flag.Service.Collector.Apps.DefaultTeam),
+			UniqueApp:      config.Viper.GetBool(config.Flag.Service.App.Unique),
 		}
 
 		operatorCollector, err = collector.NewSet(c)


### PR DESCRIPTION
Two app-operators are sending same metrics over its collectors. it only needs to send metrics for app CRs that are responsible. 

## Checklist

- [x] Update changelog in CHANGELOG.md.