### PR TITLE
Update app alert routing for Atlas and Biscuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Updated app to team mappings for app alerts.
+
 ## [1.1.10] - 2020-08-04
 
 ### Added

--- a/helm/app-operator/templates/configmap.yaml
+++ b/helm/app-operator/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
           defaultTeam: "batman"
           teams: |
             atlas: "g8s-efk,g8s-grafana,g8s-oauth2-proxy,g8s-prometheus,gatekeeper-app,gatekeeper-control-plane-rules"
-            biscuit: "cluster-service,dex-app,g8s-cert-manager,kubernetesd,organization-operator,rbac-operator,tokend,userd,vault-app,vault-exporter"
+            biscuit: "api,cluster-service,dex-app,g8s-cert-manager,kubernetesd,organization-operator,rbac-operator,tokend,userd,vault-app,vault-exporter"
             celestial: "azure-collector,azure-operator,etcd-backup-operator,releases-azure"
             firecracker: "aws-operator,cluster-operator,kiam,releases-aws"
             ludacris: "bridge-operator,cert-exporter,cert-operator,coredns-app,flannel-operator,ignition-operator,kvm-operator,kube-state-metrics-app,metrics-server-app,net-exporter,node-operator,release-operator,releases-kvm"

--- a/helm/app-operator/templates/configmap.yaml
+++ b/helm/app-operator/templates/configmap.yaml
@@ -21,9 +21,9 @@ data:
           defaultTeam: "batman"
           teams: |
             atlas: "g8s-efk,g8s-grafana,g8s-oauth2-proxy,g8s-prometheus,gatekeeper-app,gatekeeper-control-plane-rules"
-            biscuit: "cluster-service,dex-app,g8s-cert-manager,kubernetesd,organization-operator,rbac-operator,tokend,userd,vault-app"
+            biscuit: "cluster-service,dex-app,g8s-cert-manager,kubernetesd,organization-operator,rbac-operator,tokend,userd,vault-app,vault-exporter"
             celestial: "azure-collector,azure-operator,etcd-backup-operator,releases-azure"
-            firecracker: "aws-operator,cluster-operator,kiam,releases-aws,route53-manager"
+            firecracker: "aws-operator,cluster-operator,kiam,releases-aws"
             ludacris: "bridge-operator,cert-exporter,cert-operator,coredns-app,flannel-operator,ignition-operator,kvm-operator,kube-state-metrics-app,metrics-server-app,net-exporter,node-operator,release-operator,releases-kvm"
       helm:
         http:

--- a/helm/app-operator/templates/configmap.yaml
+++ b/helm/app-operator/templates/configmap.yaml
@@ -20,10 +20,11 @@ data:
         apps:
           defaultTeam: "batman"
           teams: |
+            atlas: "g8s-efk,g8s-grafana,g8s-oauth2-proxy,g8s-prometheus,gatekeeper-app,gatekeeper-control-plane-rules"
+            biscuit: "cluster-service,dex-app,g8s-cert-manager,kubernetesd,organization-operator,rbac-operator,tokend,userd,vault-app"
             celestial: "azure-collector,azure-operator,etcd-backup-operator,releases-azure"
-            firecracker: "aws-operator,cluster-operator,kiam,releases-aws"
+            firecracker: "aws-operator,cluster-operator,kiam,releases-aws,route53-manager"
             ludacris: "bridge-operator,cert-exporter,cert-operator,coredns-app,flannel-operator,ignition-operator,kvm-operator,kube-state-metrics-app,metrics-server-app,net-exporter,node-operator,release-operator,releases-kvm"
-            magic: "cluster-service,dex-app,g8s-cert-manager,g8s-efk,g8s-grafana,g8s-oauth2-proxy,g8s-prometheus,gatekeeper-app,gatekeeper-control-plane-rules,kubernetesd,rbac-operator,tokend,userd,vault-app"
       helm:
         http:
           clientTimeout: '{{ .Values.Installation.V1.Helm.HTTP.ClientTimeout }}'


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/g8s-prometheus/pull/989.

I would like to keep the per team mapping. But it should be routed based on the team label on the app metrics. Having app names in the alerts doesn't scale.

This mapping in the configmap is dumb and gets out of date. It is temporary until the Representation of Apps story which is next for Batman after Helm 3. 

With that the maintainers field in Chart.yaml will become the source of truth and team will be a field in the new appcatalogentry CRs.



## Checklist

- [x] Update changelog in CHANGELOG.md.