### PR TITLE
Add apps mapping for Firecracker and Celestial

### DIFF
--- a/helm/app-operator/templates/configmap.yaml
+++ b/helm/app-operator/templates/configmap.yaml
@@ -20,8 +20,8 @@ data:
         apps:
           defaultTeam: "batman"
           teams: |
-            celestial: "azure-collector,azure-operator,etcd-backup-operator,releases-azure"
-            firecracker: "aws-operator,cluster-operator,kiam,releases-aws"
+            celestial: "azure-admission-controller,azure-collector,azure-operator,etcd-backup-operator,releases-azure"
+            firecracker: "admission-controller,aws-operator,cluster-operator,kiam,releases-aws,route53-manager"
             ludacris: "bridge-operator,cert-exporter,cert-operator,coredns-app,flannel-operator,ignition-operator,kvm-operator,kube-state-metrics-app,metrics-server-app,net-exporter,node-operator,release-operator,releases-kvm"
             magic: "cluster-service,dex-app,g8s-cert-manager,g8s-efk,g8s-grafana,g8s-oauth2-proxy,g8s-prometheus,gatekeeper-app,gatekeeper-control-plane-rules,kubernetesd,rbac-operator,tokend,userd,vault-app"
       helm:


### PR DESCRIPTION
We need to update the apps to team mappings as its out of date. This is used to route app failed alerts.

This mapping in the configmap is dumb and gets out of date. It's temporary until the Representation of Apps story which is next for Batman after Helm 3.

With that the maintainers field in Chart.yaml will become the source of truth and team will be a field in the new appcatalogentry CRs.


