### PR TITLE
helm2: Use v1.0.10 not v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-## [1.1.0] - 2020-09-07
+## [1.0.10] - 2020-09-07
 
 ### Added
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "app-operator"
 	source      = "https://github.com/giantswarm/app-operator"
-	version     = "1.1.0"
+	version     = "1.0.10"
 )
 
 // AppControlPlaneVersion is always 0.0.0 for control plane app CRs. These CRs


### PR DESCRIPTION
This has to be a patch bump because we already released v1.1.0 and it has Helm 3 support.


## Checklist

- [x] Update changelog in CHANGELOG.md.