### PR TITLE
Update changelog and fix badge link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Add resource version for chart configmaps and secrets to the chart CR to reduce latency of update events.
+
+## [2.2.0] - 2020-09-07
+
+### Added
+
 - Add monitoring label
 - Add validation resource that checks if references to other resources exist in
 app CRs. A message is added to the app CR status for the user.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/app-operator.svg?style=shield)](https://circleci.com/gh/giantswarm/) 
+[![CircleCI](https://circleci.com/gh/giantswarm/app-operator.svg?style=shield)](https://circleci.com/gh/giantswarm/app-operator) 
 
 # app-operator
 


### PR DESCRIPTION
We used a release branch for v2.2.0 because of problems with the automation. 

This gets the changelog in sync.
 
## Checklist

- [x] Update changelog in CHANGELOG.md.