### PR TITLE
Update after v2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+## [2.3.0] - 2020-09-17
+
 ### Added
 
 - Add resource version for chart configmaps and secrets to the chart CR to reduce latency of update events.
@@ -158,7 +160,9 @@ from Helm 2 to Helm 3.
 
 - Flattening operator release structure.
 
-[Unreleased]: https://github.com/giantswarm/app-operator/compare/v2.1.1...HEAD
+[Unreleased]: https://github.com/giantswarm/app-operator/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/giantswarm/app-operator/compare/v2.2.0...v2.3.0
+[2.2.0]: https://github.com/giantswarm/app-operator/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/giantswarm/app-operator/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/giantswarm/app-operator/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/giantswarm/app-operator/compare/v1.1.11...v2.0.0

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "app-operator"
 	source      = "https://github.com/giantswarm/app-operator"
-	version     = "2.1.2-dev"
+	version     = "2.3.1-dev"
 )
 
 // AppControlPlaneVersion is always 0.0.0 for control plane app CRs. These CRs


### PR DESCRIPTION
Release was created manually due to a problem with the automation. https://github.com/giantswarm/app-operator/releases/tag/v2.3.0

This gets master in sync.


## Checklist

- [x] Update changelog in CHANGELOG.md.