### PR TITLE
Helm2; Delete finalizers if only it is presented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Skip deleting finalizers on chart-operator if not presented.
+- Skip removing finalizer for chart-operator chart CR if its not present.
 
 ## [1.0.14] - 2020-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip deleting finalizers on chart-operator if not presented.
+
 ## [1.0.14] - 2020-10-16
 
 ### Fixed

--- a/service/controller/app/resource/chart/delete.go
+++ b/service/controller/app/resource/chart/delete.go
@@ -30,25 +30,10 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	}
 
 	if key.AppName(cr) == key.ChartOperatorAppName {
-		// `chart-operator` helm release is already deleted by the `chartoperator` resource at this point.
-		// So app-operator needs to remove finalizers so the chart-operator chart CR is deleted.
-		patch := []patch{
-			{
-				Op:   "remove",
-				Path: "/metadata/finalizers",
-			},
-		}
-		bytes, err := json.Marshal(patch)
+		err = r.removeFinalizer(ctx, chart)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting finalizers on Chart CR %#q in namespace %#q", chart.Name, chart.Namespace))
-		_, err = cc.Clients.G8s.ApplicationV1alpha1().Charts(chart.Namespace).Patch(chart.Name, types.JSONPatchType, bytes)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted finalizers on Chart CR %#q in namespace %#q", chart.Name, chart.Namespace))
 	}
 
 	if chart != nil && chart.Name != "" {

--- a/service/controller/app/resource/chart/delete.go
+++ b/service/controller/app/resource/chart/delete.go
@@ -2,14 +2,12 @@ package chart
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/resource/crud"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/app-operator/service/controller/app/controllercontext"
 	"github.com/giantswarm/app-operator/service/controller/app/key"
@@ -17,10 +15,6 @@ import (
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
 	cr, err := key.ToCustomResource(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/app/resource/chart/resource.go
+++ b/service/controller/app/resource/chart/resource.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/giantswarm/app-operator/service/controller/app/controllercontext"
-	"k8s.io/apimachinery/pkg/types"
 	"reflect"
 	"strings"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/app-operator/pkg/annotation"
+	"github.com/giantswarm/app-operator/service/controller/app/controllercontext"
 )
 
 const (

--- a/service/controller/app/resource/chart/resource.go
+++ b/service/controller/app/resource/chart/resource.go
@@ -1,6 +1,11 @@
 package chart
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/giantswarm/app-operator/service/controller/app/controllercontext"
+	"k8s.io/apimachinery/pkg/types"
 	"reflect"
 	"strings"
 
@@ -59,6 +64,42 @@ func New(config Config) (*Resource, error) {
 
 func (r *Resource) Name() string {
 	return Name
+}
+
+func (r *Resource) removeFinalizer(ctx context.Context, chart *v1alpha1.Chart) error {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(chart.Finalizers) == 0 {
+		// Return early as nothing to do.
+		return nil
+	}
+
+	// `chart-operator` helm release is already deleted by the `chartoperator` resource at this point.
+	// So app-operator needs to remove finalizers so the chart-operator chart CR is deleted.
+	patch := []patch{
+		{
+			Op:   "remove",
+			Path: "/metadata/finalizers",
+		},
+	}
+	bytes, err := json.Marshal(patch)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting finalizers on Chart CR %#q in namespace %#q", chart.Name, chart.Namespace))
+
+	_, err = cc.Clients.G8s.ApplicationV1alpha1().Charts(chart.Namespace).Patch(chart.Name, types.JSONPatchType, bytes)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted finalizers on Chart CR %#q in namespace %#q", chart.Name, chart.Namespace))
+
+	return nil
 }
 
 // equals asseses the equality of ReleaseStates with regards to distinguishing fields.


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/13648

There was an issue with deleting finalizers in chart-operator app CRs. See below for logs. 
https://gigantic.slack.com/archives/C03CPNRTS/p1603111918071400?thread_ts=1603109603.061700&cid=C03CPNRTS

## Checklist

- [x] Update changelog in CHANGELOG.md.