### PR TITLE
Delete finalizer only if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip removing finalizer for chart-operator chart CR if its not present.
+
 ## [2.3.4] - 2020-10-16
 
 ### Fixed

--- a/service/controller/app/resource/chart/resource.go
+++ b/service/controller/app/resource/chart/resource.go
@@ -1,14 +1,20 @@
 package chart
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"reflect"
 	"strings"
 
 	"github.com/giantswarm/apiextensions/v2/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/app-operator/v2/pkg/annotation"
+	"github.com/giantswarm/app-operator/v2/service/controller/app/controllercontext"
 )
 
 const (
@@ -59,6 +65,42 @@ func New(config Config) (*Resource, error) {
 
 func (r *Resource) Name() string {
 	return Name
+}
+
+func (r *Resource) removeFinalizer(ctx context.Context, chart *v1alpha1.Chart) error {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(chart.Finalizers) == 0 {
+		// Return early as nothing to do.
+		return nil
+	}
+
+	// `chart-operator` helm release is already deleted by the `chartoperator` resource at this point.
+	// So app-operator needs to remove finalizers so the chart-operator chart CR is deleted.
+	patch := []patch{
+		{
+			Op:   "remove",
+			Path: "/metadata/finalizers",
+		},
+	}
+	bytes, err := json.Marshal(patch)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting finalizers on Chart CR %#q in namespace %#q", chart.Name, chart.Namespace))
+
+	_, err = cc.Clients.K8s.G8sClient().ApplicationV1alpha1().Charts(chart.Namespace).Patch(ctx, chart.Name, types.JSONPatchType, bytes, metav1.PatchOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted finalizers on Chart CR %#q in namespace %#q", chart.Name, chart.Namespace))
+
+	return nil
 }
 
 // equals asseses the equality of ReleaseStates with regards to distinguishing fields.


### PR DESCRIPTION
Toward giantswarm/giantswarm#13648

There was an issue with deleting finalizers in chart-operator app CRs. See below for logs.
https://gigantic.slack.com/archives/C03CPNRTS/p1603111918071400?thread_ts=1603109603.061700&cid=C03CPNRTS

## Checklist

- [x] Update changelog in CHANGELOG.md.