### PR TITLE
Using resourceVersion on comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Using resourceVersion of configmap on comparison instead of listing option.
+
 ## [2.4.0] - 2020-10-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Using resourceVersion of configmap on comparison instead of listing option.
+- Use resourceVersion of configmap for comparison instead of listing option.
 
 ## [2.4.0] - 2020-10-23
 


### PR DESCRIPTION
After deploying the latest app-operator, we are seeing this issue from most of CPs. 

```
I 10/25 14:17:52 failed to get configmap object since error event: `&Status{ListMeta:ListMeta{SelfLink:,ResourceVersion:,Continue:,RemainingItemCount:nil,},Status:Failure,Message:too old resource version: 146668832 (147486582),Reason:Expired,Details:nil,Code:410,}` | app-operator/v2/service/watcher/configmap/watch.go:62
```

Even though the app-operator is trying to get configmaps with the latest resourceVersion, API returned errors that resourceVersion is too old. 
So I'm going to use resourceVersion in comparison, not inside list options. 

## Checklist

- [x] Update changelog in CHANGELOG.md.