### PR TITLE
Using app CR's resourceVersion as webhook token. 

### DIFF
--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -30,4 +30,7 @@ const (
 
 	// WebhookURL is the URL that chart-operator reports chart updates.
 	WebhookURL = "webhook-url"
+
+	// WebhookToken is the string that chart-operator send together when updating status.
+	WebhookToken = "webhook-token"
 )

--- a/server/endpoint/status/error.go
+++ b/server/endpoint/status/error.go
@@ -19,3 +19,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var wrongTokenError = &microerror.Error{
+	Kind: "wrongTokenError",
+}
+
+// IsWrongTokenError asserts wrongTokenError.
+func IsWrongTokenError(err error) bool {
+	return microerror.Cause(err) == wrongTokenError
+}

--- a/server/endpoint/status/request.go
+++ b/server/endpoint/status/request.go
@@ -9,5 +9,6 @@ type Request struct {
 	LastDeployed v1.Time `json:"last_deployed"`
 	Reason       string  `json:"reason"`
 	Status       string  `json:"status"`
+	Token        string  `json:"token"`
 	Version      string  `json:"version"`
 }

--- a/service/controller/app/resource/chart/desired.go
+++ b/service/controller/app/resource/chart/desired.go
@@ -74,16 +74,19 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 
 	annotations := generateAnnotations(cr.GetAnnotations())
 
-	if key.InCluster(cr) {
-		u, err := url.Parse(r.webhookBaseURL)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
+	u, err := url.Parse(r.webhookBaseURL)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 
-		u.Path = path.Join(u.Path, "status", cr.Namespace, cr.Name)
+	u.Path = path.Join(u.Path, "status", cr.Namespace, cr.Name)
 
-		webhookAnnotation := fmt.Sprintf("%s/%s", annotation.ChartOperatorPrefix, annotation.WebhookURL)
-		annotations[webhookAnnotation] = u.String()
+	webhookAnnotation := fmt.Sprintf("%s/%s", annotation.ChartOperatorPrefix, annotation.WebhookURL)
+	annotations[webhookAnnotation] = u.String()
+
+	if !key.InCluster(cr) {
+		webhookTokenAnnotation := fmt.Sprintf("%s/%s", annotation.ChartOperatorPrefix, annotation.WebhookToken)
+		annotations[webhookTokenAnnotation] = cr.GetResourceVersion()
 	}
 
 	if len(annotations) > 0 {

--- a/service/controller/app/resource/chart/desired_test.go
+++ b/service/controller/app/resource/chart/desired_test.go
@@ -31,8 +31,9 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 			name: "case 0: flawless flow",
 			obj: &v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "my-cool-prometheus",
-					Namespace: "default",
+					Name:            "my-cool-prometheus",
+					Namespace:       "default",
+					ResourceVersion: "1234",
 					Labels: map[string]string{
 						"app":                                "prometheus",
 						"app-operator.giantswarm.io/version": "1.0.0",
@@ -95,6 +96,10 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 						"chart-operator.giantswarm.io/version": "1.0.0",
 						"giantswarm.io/managed-by":             "app-operator",
 					},
+					Annotations: map[string]string{
+						"chart-operator.giantswarm.io/webhook-token": "1234",
+						"chart-operator.giantswarm.io/webhook-url":   "http://webhook/status/default/my-cool-prometheus",
+					},
 				},
 				Spec: v1alpha1.ChartSpec{
 					Config: v1alpha1.ChartSpecConfig{
@@ -114,8 +119,9 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 			name: "case 1: generating catalog url failed",
 			obj: &v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "my-cool-prometheus",
-					Namespace: "default",
+					Name:            "my-cool-prometheus",
+					Namespace:       "default",
+					ResourceVersion: "1234",
 					Labels: map[string]string{
 						"app":                                "prometheus",
 						"app-operator.giantswarm.io/version": "1.0.0",
@@ -177,6 +183,10 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 						"app":                                  "prometheus",
 						"chart-operator.giantswarm.io/version": "1.0.0",
 						"giantswarm.io/managed-by":             "app-operator",
+					},
+					Annotations: map[string]string{
+						"chart-operator.giantswarm.io/webhook-token": "1234",
+						"chart-operator.giantswarm.io/webhook-url":   "http://webhook/status/default/my-cool-prometheus",
 					},
 				},
 				Spec: v1alpha1.ChartSpec{


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/13201

We need an authentication token for app-operator's webhook endpoint. 
`app` CR's resourceVersion is perfect for that matter since we can also reduce the duplicate status updating jobs. 

## Checklist

- [ ] Update changelog in CHANGELOG.md.