### PR TITLE
Reuse clients in clients resource when app CR uses inCluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ tenant clusters.
 - Use validation logic from the app library.
 - Include restrictions data from app metadata files in appcatalogentry CRs.
 
+### Fixed
+
+- Reuse clients in clients resource when app CR uses inCluster.
+
 ## [2.7.0] - 2020-11-09
 
 ### Added


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14755

This is to help with the performance problems we're seeing in ghost due to a high volume of requests to the K8s API server.

Currently we create a new k8sclient per app CR. This includes the dynamic API which results in requests to the discovery API.

For in cluster app CRs we can just reuse the existing clients. For tenant app CRs we can use the controller-runtime client. I'll do that in the next PR.

## Checklist

- [x] Update changelog in CHANGELOG.md.