### PR TITLE
Make resync period configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Added
 
 - Print difference between the current chart and desired chart.
+- Make resync period configurable for use in integration tests.
 
 ## [2.8.0] - 2020-12-15
 

--- a/flag/service/operatorkit/operatorkit.go
+++ b/flag/service/operatorkit/operatorkit.go
@@ -1,0 +1,7 @@
+package operatorkit
+
+// Operatorkit is a data structure to hold operatorkit specific
+// configuration.
+type Operatorkit struct {
+	ResyncPeriod string
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -7,13 +7,15 @@ import (
 	"github.com/giantswarm/app-operator/v2/flag/service/chart"
 	"github.com/giantswarm/app-operator/v2/flag/service/helm"
 	"github.com/giantswarm/app-operator/v2/flag/service/image"
+	"github.com/giantswarm/app-operator/v2/flag/service/operatorkit"
 )
 
 // Service is an intermediate data structure for command line configuration flags.
 type Service struct {
-	App        app.App
-	Chart      chart.Chart
-	Helm       helm.Helm
-	Image      image.Image
-	Kubernetes kubernetes.Kubernetes
+	App         app.App
+	Chart       chart.Chart
+	Helm        helm.Helm
+	Image       image.Image
+	Kubernetes  kubernetes.Kubernetes
+	Operatorkit operatorkit.Operatorkit
 }

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/microkit v0.2.2
-	github.com/giantswarm/micrologger v0.4.0
+	github.com/giantswarm/micrologger v0.5.0
 	github.com/giantswarm/operatorkit/v4 v4.0.0
 	github.com/giantswarm/to v0.3.0
 	github.com/giantswarm/versionbundle v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ github.com/giantswarm/micrologger v0.3.3/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeV
 github.com/giantswarm/micrologger v0.3.4/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
 github.com/giantswarm/micrologger v0.4.0 h1:2EpnX86HKpqUNY8C4qbB2SzniB4bgES8Cd/mYrVyOrI=
 github.com/giantswarm/micrologger v0.4.0/go.mod h1:xsD5laBXORMy/P34IHZMK0y/D1gTkYtASUL4gUm5KN4=
+github.com/giantswarm/micrologger v0.5.0 h1:/f2knkyf4bZw3L5F48R7VENiEKPb3Sjnzrg46+Ja5vk=
+github.com/giantswarm/micrologger v0.5.0/go.mod h1:J/jbt7A8eixqE40yq4JY8Hdbs/qeboe2FjHlq05UWjA=
 github.com/giantswarm/operatorkit/v4 v4.0.0 h1:rC3MZGA6Rg2HeEbn5poPH/EWHpJk6NpnbpBWc6t7w7Y=
 github.com/giantswarm/operatorkit/v4 v4.0.0/go.mod h1:9VLDXCofhooOPbRt3XCZQmMZJ0tW7X3x7G/2Sz3kb5o=
 github.com/giantswarm/to v0.3.0 h1:cEzMYkWLGI3cI8x3a0L3nPCQYJTb/cAaqcIPvxnDmpQ=

--- a/helm/app-operator/templates/configmap.yaml
+++ b/helm/app-operator/templates/configmap.yaml
@@ -30,3 +30,5 @@ data:
         registry: '{{ .Values.Installation.V1.Registry.Domain }}' 
       kubernetes:
         incluster: true
+      operatorkit:
+        resyncPeriod: '{{ .Values.operatorkit.resyncPeriod }}' 

--- a/helm/app-operator/values.yaml
+++ b/helm/app-operator/values.yaml
@@ -30,6 +30,9 @@ Installation:
       AppOperator:
         WebhookAuthToken: ""
 
+operatorkit:
+  resyncPeriod: "5m"
+
 project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"

--- a/main.go
+++ b/main.go
@@ -159,6 +159,7 @@ func mainWithError() (err error) {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CrtFile, "", "Certificate file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Watch.Namespace, "default", "The namespace where appcatalog and app CRs are located.")
+	daemonCommand.PersistentFlags().String(f.Service.Operatorkit.ResyncPeriod, "5m", "Resync period after which a complete resync of all runtime objects is performed.")
 
 	err = newCommand.CobraCommand().Execute()
 	if err != nil {

--- a/service/controller/app/app.go
+++ b/service/controller/app/app.go
@@ -93,11 +93,12 @@ func NewApp(config Config) (*App, error) {
 	var appController *controller.Controller
 	{
 		c := controller.Config{
-			InitCtx:   initCtxFunc,
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
-			Resources: resources,
-			Selector:  label.AppVersionSelector(config.UniqueApp),
+			InitCtx:      initCtxFunc,
+			K8sClient:    config.K8sClient,
+			Logger:       config.Logger,
+			ResyncPeriod: 30 * time.Second,
+			Resources:    resources,
+			Selector:     label.AppVersionSelector(config.UniqueApp),
 			NewRuntimeObjectFunc: func() runtime.Object {
 				return new(v1alpha1.App)
 			},

--- a/service/controller/app/app.go
+++ b/service/controller/app/app.go
@@ -26,6 +26,7 @@ type Config struct {
 	ChartNamespace    string
 	HTTPClientTimeout time.Duration
 	ImageRegistry     string
+	ResyncPeriod      time.Duration
 	UniqueApp         bool
 	WebhookAuthToken  string
 	WebhookBaseURL    string
@@ -53,6 +54,9 @@ func NewApp(config Config) (*App, error) {
 	}
 	if config.ImageRegistry == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ImageRegistry must not be empty", config)
+	}
+	if config.ResyncPeriod == 0 {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ResyncPeriod must not be empty", config)
 	}
 	if config.WebhookBaseURL == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.WebhookBaseURL not be empty", config)
@@ -96,7 +100,7 @@ func NewApp(config Config) (*App, error) {
 			InitCtx:      initCtxFunc,
 			K8sClient:    config.K8sClient,
 			Logger:       config.Logger,
-			ResyncPeriod: 30 * time.Second,
+			ResyncPeriod: config.ResyncPeriod,
 			Resources:    resources,
 			Selector:     label.AppVersionSelector(config.UniqueApp),
 			NewRuntimeObjectFunc: func() runtime.Object {

--- a/service/service.go
+++ b/service/service.go
@@ -82,6 +82,7 @@ func New(config Config) (*Service, error) {
 			ChartNamespace:    config.Viper.GetString(config.Flag.Service.Chart.Namespace),
 			HTTPClientTimeout: config.Viper.GetDuration(config.Flag.Service.Helm.HTTP.ClientTimeout),
 			ImageRegistry:     config.Viper.GetString(config.Flag.Service.Image.Registry),
+			ResyncPeriod:      config.Viper.GetDuration(config.Flag.Service.Operatorkit.ResyncPeriod),
 			UniqueApp:         config.Viper.GetBool(config.Flag.Service.App.Unique),
 			WebhookAuthToken:  config.Viper.GetString(config.Flag.Service.Chart.WebhookAuthToken),
 			WebhookBaseURL:    config.Viper.GetString(config.Flag.Service.Chart.WebhookBaseURL),


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14666

Makes the resync period configurable so we can use a lower value in integration tests when the operator is installed by apptestctl. 

## Checklist

- [x] Update changelog in CHANGELOG.md.