### PR TITLE
Bump app version to v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+- Update app, with changes to configmap and secret validation for App CRs
+  managed by `config-controller`.
+
 ## [3.0.0] - 2021-01-05
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/giantswarm/apiextensions/v3 v3.14.0
-	github.com/giantswarm/app/v4 v4.0.0
+	github.com/giantswarm/app/v4 v4.1.0
 	github.com/giantswarm/appcatalog v0.3.2
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/errors v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -258,12 +258,9 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/giantswarm/apiextensions/v3 v3.4.0/go.mod h1:MMLkRJta4mbTbrikP9LewADiCL+55LmsagyhdTU7XAY=
-github.com/giantswarm/apiextensions/v3 v3.11.0/go.mod h1:f+dFUDLroK50aCGzvpqPw/jCFCCgJqdEMf/xNSJBI+A=
 github.com/giantswarm/apiextensions/v3 v3.13.0/go.mod h1:f+dFUDLroK50aCGzvpqPw/jCFCCgJqdEMf/xNSJBI+A=
 github.com/giantswarm/apiextensions/v3 v3.14.0 h1:/o7Mj7Yl0rEkOrkZI9HElsJDTeUhFaerrvgZkr72TW8=
 github.com/giantswarm/apiextensions/v3 v3.14.0/go.mod h1:4XD4M9+H2xhalpdXPB8x0MIA6NhYzXGIS5eb7Q7pMz0=
-github.com/giantswarm/app/v4 v4.0.0 h1:8PA0Hr6HRBbRS2KEWi5fSMq7rB4VdI2h0g9xI2ssLR4=
-github.com/giantswarm/app/v4 v4.0.0/go.mod h1:OiMkgrgxGtBNsTEHoF0hE9Sisn2onBxlc+dWHIBJPP4=
 github.com/giantswarm/app/v4 v4.1.0 h1:f6Sj8Dz2qgPjsCQPq901NaAvG5MRc97dfX5PFkgj0l8=
 github.com/giantswarm/app/v4 v4.1.0/go.mod h1:HV4WjLb6x8SMBHw+O9n4SF/LPAmYkgObsvrYDesOZ8c=
 github.com/giantswarm/appcatalog v0.3.2 h1:pH0ASrizU7QcAK4oZtrPXAi4pqMFJOsjCPRLY0uLFEo=
@@ -293,7 +290,6 @@ github.com/giantswarm/microkit v0.2.2 h1:BNK55FyS+AXls6mH+81Iloo3z2+FRWqeEz2jYb7
 github.com/giantswarm/microkit v0.2.2/go.mod h1:XCj0vA/+jHiM03XDMlcWuvYdgZQyNS3O7ZVHDOUCYA8=
 github.com/giantswarm/micrologger v0.3.1/go.mod h1:PjAgtcJ922ZMX/Aa05IPi0bdYvOj2P7pZ7+6dBShMQs=
 github.com/giantswarm/micrologger v0.3.3/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
-github.com/giantswarm/micrologger v0.3.4/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
 github.com/giantswarm/micrologger v0.4.0/go.mod h1:xsD5laBXORMy/P34IHZMK0y/D1gTkYtASUL4gUm5KN4=
 github.com/giantswarm/micrologger v0.5.0 h1:/f2knkyf4bZw3L5F48R7VENiEKPb3Sjnzrg46+Ja5vk=
 github.com/giantswarm/micrologger v0.5.0/go.mod h1:J/jbt7A8eixqE40yq4JY8Hdbs/qeboe2FjHlq05UWjA=

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,8 @@ github.com/giantswarm/apiextensions/v3 v3.14.0 h1:/o7Mj7Yl0rEkOrkZI9HElsJDTeUhFa
 github.com/giantswarm/apiextensions/v3 v3.14.0/go.mod h1:4XD4M9+H2xhalpdXPB8x0MIA6NhYzXGIS5eb7Q7pMz0=
 github.com/giantswarm/app/v4 v4.0.0 h1:8PA0Hr6HRBbRS2KEWi5fSMq7rB4VdI2h0g9xI2ssLR4=
 github.com/giantswarm/app/v4 v4.0.0/go.mod h1:OiMkgrgxGtBNsTEHoF0hE9Sisn2onBxlc+dWHIBJPP4=
+github.com/giantswarm/app/v4 v4.1.0 h1:f6Sj8Dz2qgPjsCQPq901NaAvG5MRc97dfX5PFkgj0l8=
+github.com/giantswarm/app/v4 v4.1.0/go.mod h1:HV4WjLb6x8SMBHw+O9n4SF/LPAmYkgObsvrYDesOZ8c=
 github.com/giantswarm/appcatalog v0.3.2 h1:pH0ASrizU7QcAK4oZtrPXAi4pqMFJOsjCPRLY0uLFEo=
 github.com/giantswarm/appcatalog v0.3.2/go.mod h1:cjOuCqi8gWudFY0ogbp4ukSV4Vff6kfInR9VdrX+7yI=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=

--- a/service/controller/app/resource/validation/create.go
+++ b/service/controller/app/resource/validation/create.go
@@ -21,12 +21,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	_, err = r.appValidator.ValidateApp(ctx, cr)
-	if validation.IsAppDependencyNotReady(err) {
-		r.logger.Debugf(ctx, "dependent configuration is not ready: %#q", err)
-		r.logger.Debugf(ctx, "cancelling reconciliation")
-		reconciliationcanceledcontext.SetCanceled(ctx)
-		return nil
-	}
 	if validation.IsValidationError(err) {
 		r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("validation error %s", err.Error()))
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14821

Otherwise `app-operator` will still be waiting for `configMap` & `secret` fields to be filled in. This is no longer expected behaviour.

## Checklist

- [x] Update changelog in CHANGELOG.md.