### PR TITLE
Use key funcs in integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@0.10.1
+  architect: giantswarm/architect@1.1.1
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@@0.10.1
+  architect: giantswarm/architect@0.10.1
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@1.1.1
+  architect: giantswarm/architect@@0.10.1
 
 workflows:
   build:

--- a/integration/key/key.go
+++ b/integration/key/key.go
@@ -44,6 +44,10 @@ func StableCatalogName() string {
 	return "giantswarm"
 }
 
+func StableCatalogStorageURL() string {
+	return "https://giantswarm.github.io/giantswarm-catalog"
+}
+
 func TestAppName() string {
 	return "test-app"
 }

--- a/integration/key/key.go
+++ b/integration/key/key.go
@@ -2,12 +2,26 @@
 
 package key
 
+import "fmt"
+
 func AppCatalogConfigMapName() string {
 	return "appcatalog-config"
 }
 
 func AppCatalogEntryName() string {
 	return "giantswarm-prometheus-operator-app-0.3.4"
+}
+
+func ChartOperatorName() string {
+	return "chart-operator"
+}
+
+func ChartOperatorUniqueName() string {
+	return fmt.Sprintf("%s-unique", ChartOperatorName())
+}
+
+func ChartOperatorVersion() string {
+	return "2.7.0"
 }
 
 func ControlPlaneTestCatalogStorageURL() string {
@@ -19,7 +33,7 @@ func DefaultCatalogName() string {
 }
 
 func DefaultCatalogStorageURL() string {
-	return "https://giantswarm.github.com/default-catalog"
+	return "https://giantswarm.github.io/default-catalog"
 }
 
 func Namespace() string {
@@ -30,11 +44,7 @@ func StableCatalogName() string {
 	return "giantswarm"
 }
 
-func StableCatalogStorageURL() string {
-	return "https://giantswarm.github.com/giantswarm-catalog"
-}
-
-func TestAppReleaseName() string {
+func TestAppName() string {
 	return "test-app"
 }
 

--- a/integration/key/key.go
+++ b/integration/key/key.go
@@ -2,7 +2,11 @@
 
 package key
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/giantswarm/app-operator/v3/pkg/project"
+)
 
 func AppCatalogConfigMapName() string {
 	return "appcatalog-config"
@@ -10,6 +14,10 @@ func AppCatalogConfigMapName() string {
 
 func AppCatalogEntryName() string {
 	return "giantswarm-prometheus-operator-app-0.3.4"
+}
+
+func AppOperatorUniqueName() string {
+	return fmt.Sprintf("%s-unique", project.Name())
 }
 
 func ChartOperatorName() string {
@@ -21,7 +29,7 @@ func ChartOperatorUniqueName() string {
 }
 
 func ChartOperatorVersion() string {
-	return "2.7.0"
+	return "2.5.1"
 }
 
 func ControlPlaneTestCatalogStorageURL() string {

--- a/integration/setup/config.go
+++ b/integration/setup/config.go
@@ -14,10 +14,6 @@ import (
 	"github.com/giantswarm/app-operator/v3/integration/release"
 )
 
-const (
-	namespace = "giantswarm"
-)
-
 type Config struct {
 	HelmClient helmclient.Interface
 	K8s        *k8sclient.Setup

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -50,7 +50,7 @@ func installResources(ctx context.Context, config Config) error {
 	var err error
 
 	{
-		err = config.K8s.EnsureNamespaceCreated(ctx, namespace)
+		err = config.K8s.EnsureNamespaceCreated(ctx, key.Namespace())
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -125,7 +125,7 @@ func installResources(ctx context.Context, config Config) error {
 		}
 		err = config.HelmClient.InstallReleaseFromTarball(ctx,
 			operatorTarballPath,
-			namespace,
+			key.Namespace(),
 			appOperatorValues,
 			opts)
 		if err != nil {

--- a/integration/templates/chart_operator_values.go
+++ b/integration/templates/chart_operator_values.go
@@ -3,12 +3,15 @@
 package templates
 
 // ChartOperatorValues values required by chart-operator-chart.
-const ChartOperatorValues = `
-clusterDNSIP: 10.96.0.10
+const ChartOperatorValues = `clusterDNSIP: 10.96.0.10
 e2e: true
-externalDNSIP: 8.8.8.8
-image:
-  registry: "quay.io"
-tiller:
-  namespace: "giantswarm"
-`
+
+Installation:
+  V1:
+    Helm:
+      HTTP:
+        ClientTimeout: "30s"
+      Kubernetes:
+        WaitTimeout: "180s"
+    Registry:
+      Domain: "quay.io"`

--- a/integration/test/app/basic/basic_test.go
+++ b/integration/test/app/basic/basic_test.go
@@ -213,7 +213,7 @@ func TestAppLifecycle(t *testing.T) {
 	{
 		config.Logger.Debugf(ctx, "checking status for app CR %#q", key.TestAppName())
 
-		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps("giantswarm").Get(ctx, key.TestAppName(), metav1.GetOptions{})
+		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}

--- a/integration/test/app/kubeconfig/kubeconfig_test.go
+++ b/integration/test/app/kubeconfig/kubeconfig_test.go
@@ -22,10 +22,8 @@ import (
 
 const (
 	catalogConfigMapName = "default-catalog-configmap"
-	chartOperatorName    = "chart-operator"
 	clusterName          = "kind-kind"
 	kubeConfigName       = "kube-config"
-	namespace            = "giantswarm"
 )
 
 // TestAppWithKubeconfig checks app-operator can bootstrap chart-operator
@@ -71,10 +69,10 @@ func TestAppWithKubeconfig(t *testing.T) {
 	{
 		config.Logger.Debugf(ctx, "creating kubeconfig secret")
 
-		_, err = config.K8sClients.K8sClient().CoreV1().Secrets(namespace).Create(ctx, &corev1.Secret{
+		_, err = config.K8sClients.K8sClient().CoreV1().Secrets(key.Namespace()).Create(ctx, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      kubeConfigName,
-				Namespace: namespace,
+				Namespace: key.Namespace(),
 			},
 			Data: map[string][]byte{
 				"kubeConfig": bytes,
@@ -90,13 +88,13 @@ func TestAppWithKubeconfig(t *testing.T) {
 	{
 		config.Logger.Debugf(ctx, "creating catalog configmap")
 
-		_, err = config.K8sClients.K8sClient().CoreV1().ConfigMaps(namespace).Create(ctx, &corev1.ConfigMap{
+		_, err = config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.Namespace()).Create(ctx, &corev1.ConfigMap{
 			Data: map[string]string{
 				"values": templates.ChartOperatorValues,
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      catalogConfigMapName,
-				Namespace: namespace,
+				Namespace: key.Namespace(),
 			},
 		}, metav1.CreateOptions{})
 		if err != nil {
@@ -120,7 +118,7 @@ func TestAppWithKubeconfig(t *testing.T) {
 				Config: v1alpha1.AppCatalogSpecConfig{
 					ConfigMap: v1alpha1.AppCatalogSpecConfigConfigMap{
 						Name:      catalogConfigMapName,
-						Namespace: namespace,
+						Namespace: key.Namespace(),
 					},
 				},
 				Description: key.DefaultCatalogName(),
@@ -147,10 +145,10 @@ func TestAppWithKubeconfig(t *testing.T) {
 			t.Fatalf("expected nil got %#v", err)
 		}
 
-		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(namespace).Create(ctx, &v1alpha1.App{
+		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Create(ctx, &v1alpha1.App{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      chartOperatorName,
-				Namespace: namespace,
+				Name:      key.ChartOperatorName(),
+				Namespace: key.Namespace(),
 				Labels: map[string]string{
 					label.AppOperatorVersion: key.UniqueAppVersion(),
 				},
@@ -164,11 +162,11 @@ func TestAppWithKubeconfig(t *testing.T) {
 					InCluster: false,
 					Secret: v1alpha1.AppSpecKubeConfigSecret{
 						Name:      kubeConfigName,
-						Namespace: namespace,
+						Namespace: key.Namespace(),
 					},
 				},
-				Name:      chartOperatorName,
-				Namespace: namespace,
+				Name:      key.ChartOperatorName(),
+				Namespace: key.Namespace(),
 				Version:   tag,
 			},
 		}, metav1.CreateOptions{})
@@ -180,23 +178,23 @@ func TestAppWithKubeconfig(t *testing.T) {
 	}
 
 	{
-		config.Logger.Debugf(ctx, "waiting for release %#q deployed", chartOperatorName)
+		config.Logger.Debugf(ctx, "waiting for release %#q deployed", key.ChartOperatorName())
 
-		err = config.Release.WaitForReleaseStatus(ctx, namespace, chartOperatorName, helmclient.StatusDeployed)
+		err = config.Release.WaitForReleaseStatus(ctx, key.Namespace(), key.ChartOperatorName(), helmclient.StatusDeployed)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.Debugf(ctx, "waited for release %#q deployed", chartOperatorName)
+		config.Logger.Debugf(ctx, "waited for release %#q deployed", key.ChartOperatorName())
 	}
 
 	{
-		config.Logger.Debugf(ctx, "creating %#q app cr", key.TestAppReleaseName())
+		config.Logger.Debugf(ctx, "creating %#q app cr", key.TestAppName())
 
 		appCR := &v1alpha1.App{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      key.TestAppReleaseName(),
-				Namespace: namespace,
+				Name:      key.TestAppName(),
+				Namespace: key.Namespace(),
 				Labels: map[string]string{
 					label.AppOperatorVersion: key.UniqueAppVersion(),
 				},
@@ -210,30 +208,30 @@ func TestAppWithKubeconfig(t *testing.T) {
 					InCluster: false,
 					Secret: v1alpha1.AppSpecKubeConfigSecret{
 						Name:      kubeConfigName,
-						Namespace: namespace,
+						Namespace: key.Namespace(),
 					},
 				},
-				Name:      key.TestAppReleaseName(),
-				Namespace: namespace,
+				Name:      key.TestAppName(),
+				Namespace: key.Namespace(),
 				Version:   "0.1.0",
 			},
 		}
-		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(namespace).Create(ctx, appCR, metav1.CreateOptions{})
+		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Create(ctx, appCR, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.Debugf(ctx, "creating %#q app cr", key.TestAppReleaseName())
+		config.Logger.Debugf(ctx, "creating %#q app cr", key.TestAppName())
 	}
 
 	{
-		config.Logger.Debugf(ctx, "waiting for release %#q deployed", key.TestAppReleaseName())
+		config.Logger.Debugf(ctx, "waiting for release %#q deployed", key.TestAppName())
 
-		err = config.Release.WaitForReleaseStatus(ctx, namespace, key.TestAppReleaseName(), helmclient.StatusDeployed)
+		err = config.Release.WaitForReleaseStatus(ctx, key.Namespace(), key.TestAppName(), helmclient.StatusDeployed)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.Debugf(ctx, "waited for release %#q deployed", key.TestAppReleaseName())
+		config.Logger.Debugf(ctx, "waited for release %#q deployed", key.TestAppName())
 	}
 }

--- a/integration/test/app/kubeconfig/kubeconfig_test.go
+++ b/integration/test/app/kubeconfig/kubeconfig_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
-	"github.com/giantswarm/appcatalog"
 	"github.com/giantswarm/helmclient/v4/pkg/helmclient"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -140,11 +139,6 @@ func TestAppWithKubeconfig(t *testing.T) {
 	{
 		config.Logger.Debugf(ctx, "creating chart-operator app CR")
 
-		tag, err := appcatalog.GetLatestVersion(ctx, key.DefaultCatalogStorageURL(), "chart-operator", "")
-		if err != nil {
-			t.Fatalf("expected nil got %#v", err)
-		}
-
 		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Create(ctx, &v1alpha1.App{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      key.ChartOperatorName(),
@@ -167,7 +161,7 @@ func TestAppWithKubeconfig(t *testing.T) {
 				},
 				Name:      key.ChartOperatorName(),
 				Namespace: key.Namespace(),
-				Version:   tag,
+				Version:   key.ChartOperatorVersion(),
 			},
 		}, metav1.CreateOptions{})
 		if err != nil {

--- a/integration/test/watcher/configmap/configmap_test.go
+++ b/integration/test/watcher/configmap/configmap_test.go
@@ -116,11 +116,11 @@ func TestWatchingConfigMap(t *testing.T) {
 	}
 
 	{
-		config.Logger.Debugf(ctx, "creating %#q app cr", key.TestAppReleaseName())
+		config.Logger.Debugf(ctx, "creating %#q app cr", key.TestAppName())
 
 		appCR := &v1alpha1.App{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      key.TestAppReleaseName(),
+				Name:      key.TestAppName(),
 				Namespace: key.Namespace(),
 				Labels: map[string]string{
 					label.AppOperatorVersion: key.UniqueAppVersion(),
@@ -131,7 +131,7 @@ func TestWatchingConfigMap(t *testing.T) {
 				KubeConfig: v1alpha1.AppSpecKubeConfig{
 					InCluster: true,
 				},
-				Name:      key.TestAppReleaseName(),
+				Name:      key.TestAppName(),
 				Namespace: key.Namespace(),
 				UserConfig: v1alpha1.AppSpecUserConfig{
 					ConfigMap: v1alpha1.AppSpecUserConfigConfigMap{
@@ -148,7 +148,7 @@ func TestWatchingConfigMap(t *testing.T) {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.Debugf(ctx, "creating %#q app cr", key.TestAppReleaseName())
+		config.Logger.Debugf(ctx, "creating %#q app cr", key.TestAppName())
 	}
 
 	{
@@ -235,7 +235,7 @@ func TestWatchingConfigMap(t *testing.T) {
 		config.Logger.Debugf(ctx, "waiting until app CR is annotated with user configmap's resourceVersion")
 
 		o := func() error {
-			cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Get(ctx, key.TestAppReleaseName(), metav1.GetOptions{})
+			cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -285,7 +285,7 @@ func TestWatchingConfigMap(t *testing.T) {
 		config.Logger.Debugf(ctx, "waiting until app CR annotate by appcatalog configmap's resourceVersion")
 
 		o := func() error {
-			cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Get(ctx, key.TestAppReleaseName(), metav1.GetOptions{})
+			cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -313,14 +313,14 @@ func TestWatchingConfigMap(t *testing.T) {
 	}
 
 	{
-		config.Logger.Debugf(ctx, "deleting app CR %#q", key.TestAppReleaseName())
+		config.Logger.Debugf(ctx, "deleting app CR %#q", key.TestAppName())
 
-		err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Delete(ctx, key.TestAppReleaseName(), metav1.DeleteOptions{})
+		err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Delete(ctx, key.TestAppName(), metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.Debugf(ctx, "deleted app CR %#q", key.TestAppReleaseName())
+		config.Logger.Debugf(ctx, "deleted app CR %#q", key.TestAppName())
 	}
 
 	{


### PR DESCRIPTION
This got a bit big but it makes improvements to the integration tests.

Prior to  renaming the kubeconfig test to workloadcluster and using it to test the app-operator per cluster changes.

- Replaces constants with key funcs.
- Installs app-operator and chart-operator as unique so the status webhook works.
- Uses chart-operator 2.5.1 which is the latest release without VPA.

Next PR will use apptest library to create the app CRs and will release chart-operator with the VPA fix.