### PR TITLE
Rename kubeconfig test to workload cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,14 +61,6 @@ workflows:
 
       - architect/integration-test:
           context: architect
-          name: kubeconfig-integration-test
-          test-dir: "integration/test/app/kubeconfig"
-          requires:
-            - go-build
-            - push-app-operator-to-control-plane-app-catalog
-
-      - architect/integration-test:
-          context: architect
           name: appcatalogentry-integration-test
           test-dir: "integration/test/appcatalog/appcatalogentry"
           requires:
@@ -82,3 +74,12 @@ workflows:
           requires:
             - go-build
             - push-app-operator-to-control-plane-app-catalog
+
+      - architect/integration-test:
+          context: architect
+          name: workload-cluster-integration-test
+          test-dir: "integration/test/app/workload"
+          requires:
+            - go-build
+            - push-app-operator-to-control-plane-app-catalog
+

--- a/integration/test/app/workload/main_test.go
+++ b/integration/test/app/workload/main_test.go
@@ -1,6 +1,6 @@
 // +build k8srequired
 
-package kubeconfig
+package workload
 
 import (
 	"testing"

--- a/integration/test/app/workload/workload_cluster_test.go
+++ b/integration/test/app/workload/workload_cluster_test.go
@@ -1,6 +1,6 @@
 // +build k8srequired
 
-package kubeconfig
+package workload
 
 import (
 	"context"
@@ -22,9 +22,9 @@ const (
 	kubeConfigName       = "kube-config"
 )
 
-// TestAppWithKubeconfig checks app-operator can bootstrap chart-operator
+// TestWorkloadCluster checks app-operator can bootstrap chart-operator
 // when a kubeconfig is provided.
-func TestAppWithKubeconfig(t *testing.T) {
+func TestWorkloadCluster(t *testing.T) {
 	ctx := context.Background()
 	var err error
 


### PR DESCRIPTION
kubeconfig test will get extended to also install app-operator for a workload cluster. Renaming the test as prep for that.