### PR TITLE
Adding cordoned status into context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 - Delete legacy finalizers on app CRs. 
 - Reconciling appCatalog CRs only if pod is unique.
 
+### Fixed
+
+- Updating status as cordoned if app CR has cordoned annotation.
+
 ## [3.1.0] - 2021-01-13
 
 ## [3.0.0] - 2021-01-05

--- a/service/controller/app/resource/configmap/current.go
+++ b/service/controller/app/resource/configmap/current.go
@@ -45,6 +45,9 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	if key.IsAppCordoned(cr) {
 		r.logger.Debugf(ctx, "app %#q is cordoned", cr.Name)
 		r.logger.Debugf(ctx, "canceling resource")
+
+		// Adding cordon status to context
+		addStatusToContext(cc, key.CordonReason(cr), cordonedStatus)
 		resourcecanceledcontext.SetCanceled(ctx)
 		return nil, nil
 	}

--- a/service/controller/app/resource/configmap/resource.go
+++ b/service/controller/app/resource/configmap/resource.go
@@ -15,6 +15,8 @@ import (
 const (
 	// Name is the identifier of the resource.
 	Name = "configmap"
+
+	cordonedStatus = "cordoned"
 )
 
 // Config represents the configuration used to create a new configmap resource.


### PR DESCRIPTION
From the recent slack channel discussion in #area-managedapps, we found out cordoned apps are not updating their status accordingly. https://gigantic.slack.com/archives/CRZN9GLJW/p1612368461138500

This is because we delete `addStatusToContext` logic from configmap resource, which will propagate status update in the next reconciliation. 


## Checklist

- [ ] Update changelog in CHANGELOG.md.