### PR TITLE
Rename watcher to appvalue watcher

### DIFF
--- a/service/watcher/appvalue/appvalue.go
+++ b/service/watcher/appvalue/appvalue.go
@@ -1,4 +1,4 @@
-package watcher
+package appvalue
 
 import (
 	"context"

--- a/service/watcher/appvalue/cache.go
+++ b/service/watcher/appvalue/cache.go
@@ -1,4 +1,4 @@
-package watcher
+package appvalue
 
 import (
 	"context"

--- a/service/watcher/appvalue/configmap.go
+++ b/service/watcher/appvalue/configmap.go
@@ -1,4 +1,4 @@
-package watcher
+package appvalue
 
 import (
 	"context"

--- a/service/watcher/appvalue/error.go
+++ b/service/watcher/appvalue/error.go
@@ -1,4 +1,4 @@
-package watcher
+package appvalue
 
 import "github.com/giantswarm/microerror"
 

--- a/service/watcher/appvalue/secret.go
+++ b/service/watcher/appvalue/secret.go
@@ -1,4 +1,4 @@
-package watcher
+package appvalue
 
 import (
 	"context"

--- a/service/watcher/appvalue/types.go
+++ b/service/watcher/appvalue/types.go
@@ -1,4 +1,4 @@
-package watcher
+package appvalue
 
 type resourceType string
 


### PR DESCRIPTION
Renames the current watcher package to appvalue. This is prep for adding the 2nd chartstatus watcher.