### PR TITLE
For non-unique instance only watch the current namespace

### DIFF
--- a/helm/app-operator/templates/_resource.tpl
+++ b/helm/app-operator/templates/_resource.tpl
@@ -24,7 +24,7 @@ room for such suffix.
 {{- end -}}
 
 {{- define "resource.default.namespace" -}}
-giantswarm
+{{-  .Release.Namespace }}
 {{- end -}}
 
 {{/*

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -44,6 +44,11 @@ spec:
         - daemon
         - --config.dirs=/var/run/{{ include "name" . }}/configmap/
         - --config.files=config
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,27 @@
+package env
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	// EnvVarPodNamespace is the process environment variable representing the
+	// POD_NAMESPACE env var which is populated via the Downward API.
+	EnvVarPodNamespace = "POD_NAMESPACE"
+)
+
+var (
+	podNamespace string
+)
+
+func init() {
+	podNamespace = os.Getenv(EnvVarPodNamespace)
+	if podNamespace == "" {
+		panic(fmt.Sprintf("env var '%s' must not be empty", EnvVarPodNamespace))
+	}
+}
+
+func PodNamespace() string {
+	return podNamespace
+}

--- a/service/controller/app/app.go
+++ b/service/controller/app/app.go
@@ -29,6 +29,7 @@ type Config struct {
 	ChartNamespace    string
 	HTTPClientTimeout time.Duration
 	ImageRegistry     string
+	PodNamespace      string
 	ResyncPeriod      time.Duration
 	UniqueApp         bool
 	WebhookAuthToken  string
@@ -57,6 +58,9 @@ func NewApp(config Config) (*App, error) {
 	}
 	if config.ImageRegistry == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ImageRegistry must not be empty", config)
+	}
+	if config.PodNamespace == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.PodNamespace must not be empty", config)
 	}
 	if config.ResyncPeriod == 0 {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ResyncPeriod must not be empty", config)
@@ -114,6 +118,12 @@ func NewApp(config Config) (*App, error) {
 			},
 
 			Name: project.Name() + appControllerSuffix,
+		}
+
+		if !config.UniqueApp {
+			// Only watch app CRs in the current namespace. The label selector
+			// excludes the operator's own app CR which has the unique version.
+			c.Namespace = config.PodNamespace
 		}
 
 		appController, err = controller.New(c)

--- a/service/service.go
+++ b/service/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/giantswarm/app-operator/v3/flag"
+	"github.com/giantswarm/app-operator/v3/pkg/env"
 	"github.com/giantswarm/app-operator/v3/pkg/project"
 	"github.com/giantswarm/app-operator/v3/service/controller/app"
 	"github.com/giantswarm/app-operator/v3/service/controller/appcatalog"
@@ -77,6 +78,8 @@ func New(config Config) (*Service, error) {
 	}
 
 	fs := afero.NewOsFs()
+	podNamespace := env.PodNamespace()
+
 	var appController *app.App
 	{
 		c := app.Config{
@@ -87,6 +90,7 @@ func New(config Config) (*Service, error) {
 			ChartNamespace:    config.Viper.GetString(config.Flag.Service.Chart.Namespace),
 			HTTPClientTimeout: config.Viper.GetDuration(config.Flag.Service.Helm.HTTP.ClientTimeout),
 			ImageRegistry:     config.Viper.GetString(config.Flag.Service.Image.Registry),
+			PodNamespace:      podNamespace,
 			ResyncPeriod:      config.Viper.GetDuration(config.Flag.Service.Operatorkit.ResyncPeriod),
 			UniqueApp:         config.Viper.GetBool(config.Flag.Service.App.Unique),
 			WebhookAuthToken:  config.Viper.GetString(config.Flag.Service.Chart.WebhookAuthToken),


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14163

Most recent test with cluster-operator was successful. 🎉

So I'm going to start breaking down my big ball of mud in https://github.com/giantswarm/app-operator/pull/644 into smaller PRs to merge into the v4-dev branch. Shouldn't take too many. The next PR will have the new chart CR watcher.