### PR TITLE
Rename to key.GiantSwarmNamespace in integration tests

### DIFF
--- a/integration/key/key.go
+++ b/integration/key/key.go
@@ -40,7 +40,7 @@ func DefaultCatalogStorageURL() string {
 	return "https://giantswarm.github.io/default-catalog"
 }
 
-func Namespace() string {
+func GiantSwarmNamespace() string {
 	return "giantswarm"
 }
 

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -52,7 +52,7 @@ func installResources(ctx context.Context, config Config) error {
 	var err error
 
 	{
-		err = config.K8s.EnsureNamespaceCreated(ctx, key.Namespace())
+		err = config.K8s.EnsureNamespaceCreated(ctx, key.GiantSwarmNamespace())
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -127,7 +127,7 @@ func installResources(ctx context.Context, config Config) error {
 		}
 		err = config.HelmClient.InstallReleaseFromTarball(ctx,
 			operatorTarballPath,
-			key.Namespace(),
+			key.GiantSwarmNamespace(),
 			values,
 			opts)
 		if err != nil {

--- a/integration/test/app/basic/basic_test.go
+++ b/integration/test/app/basic/basic_test.go
@@ -86,7 +86,7 @@ func TestAppLifecycle(t *testing.T) {
 			ReleaseName: key.ChartOperatorUniqueName(),
 			Wait:        true,
 		}
-		err = config.HelmClient.InstallReleaseFromTarball(ctx, tarballPath, key.Namespace(), values, opts)
+		err = config.HelmClient.InstallReleaseFromTarball(ctx, tarballPath, key.GiantSwarmNamespace(), values, opts)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -100,7 +100,7 @@ func TestAppLifecycle(t *testing.T) {
 				// Install test app.
 				CatalogName:   key.DefaultCatalogName(),
 				Name:          key.TestAppName(),
-				Namespace:     key.Namespace(),
+				Namespace:     key.GiantSwarmNamespace(),
 				Version:       "0.1.0",
 				WaitForDeploy: true,
 			},
@@ -115,7 +115,7 @@ func TestAppLifecycle(t *testing.T) {
 		config.Logger.Debugf(ctx, "checking tarball URL in chart spec")
 
 		tarballURL := "https://giantswarm.github.io/default-catalog/test-app-0.1.0.tgz"
-		chart, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(key.Namespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
+		chart, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(key.GiantSwarmNamespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -132,13 +132,13 @@ func TestAppLifecycle(t *testing.T) {
 	{
 		config.Logger.Debugf(ctx, "updating app %#q", key.TestAppName())
 
-		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
+		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.GiantSwarmNamespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
 		cr.Spec.Version = "0.1.1"
-		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Update(ctx, cr, metav1.UpdateOptions{})
+		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.GiantSwarmNamespace()).Update(ctx, cr, metav1.UpdateOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -149,12 +149,12 @@ func TestAppLifecycle(t *testing.T) {
 	{
 		config.Logger.Debugf(ctx, "checking tarball URL in chart spec")
 
-		err = config.Release.WaitForReleaseVersion(ctx, key.Namespace(), key.TestAppName(), "0.1.1")
+		err = config.Release.WaitForReleaseVersion(ctx, key.GiantSwarmNamespace(), key.TestAppName(), "0.1.1")
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		chart, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(key.Namespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
+		chart, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Charts(key.GiantSwarmNamespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -170,7 +170,7 @@ func TestAppLifecycle(t *testing.T) {
 	{
 		config.Logger.Debugf(ctx, "checking status for app CR %#q", key.TestAppName())
 
-		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
+		cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.GiantSwarmNamespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -184,7 +184,7 @@ func TestAppLifecycle(t *testing.T) {
 	{
 		config.Logger.Debugf(ctx, "deleting app CR %#q", key.TestAppName())
 
-		err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Delete(ctx, key.TestAppName(), metav1.DeleteOptions{})
+		err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.GiantSwarmNamespace()).Delete(ctx, key.TestAppName(), metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -195,7 +195,7 @@ func TestAppLifecycle(t *testing.T) {
 	{
 		config.Logger.Debugf(ctx, "checking %#q release has been deleted", key.TestAppName())
 
-		err = config.Release.WaitForReleaseStatus(ctx, key.Namespace(), key.TestAppName(), helmclient.StatusUninstalled)
+		err = config.Release.WaitForReleaseStatus(ctx, key.GiantSwarmNamespace(), key.TestAppName(), helmclient.StatusUninstalled)
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -206,7 +206,7 @@ func TestAppLifecycle(t *testing.T) {
 	{
 		config.Logger.Debugf(ctx, "checking chart CR %#q has been deleted", key.TestAppName())
 
-		err = config.Release.WaitForDeletedChart(ctx, key.Namespace(), key.TestAppName())
+		err = config.Release.WaitForDeletedChart(ctx, key.GiantSwarmNamespace(), key.TestAppName())
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -217,7 +217,7 @@ func TestAppLifecycle(t *testing.T) {
 	{
 		config.Logger.Debugf(ctx, "checking app CR %#q has been deleted", key.TestAppName())
 
-		err = config.Release.WaitForDeletedApp(ctx, key.Namespace(), key.TestAppName())
+		err = config.Release.WaitForDeletedApp(ctx, key.GiantSwarmNamespace(), key.TestAppName())
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}

--- a/integration/test/app/workload/workload_cluster_test.go
+++ b/integration/test/app/workload/workload_cluster_test.go
@@ -71,7 +71,7 @@ func TestWorkloadCluster(t *testing.T) {
 				CatalogName:   key.DefaultCatalogName(),
 				KubeConfig:    kubeConfig,
 				Name:          key.ChartOperatorName(),
-				Namespace:     key.Namespace(),
+				Namespace:     key.GiantSwarmNamespace(),
 				ValuesYAML:    templates.ChartOperatorValues,
 				Version:       key.ChartOperatorVersion(),
 				WaitForDeploy: true,

--- a/integration/test/appcatalog/appcatalogentry/app_catalog_entry_test.go
+++ b/integration/test/appcatalog/appcatalogentry/app_catalog_entry_test.go
@@ -75,7 +75,7 @@ func TestAppCatalogEntry(t *testing.T) {
 
 	var entryCR *v1alpha1.AppCatalogEntry
 	{
-		appCatalogEntryName := fmt.Sprintf("%s-%s-%s", key.Namespace(), latestEntry.Name, latestEntry.Version)
+		appCatalogEntryName := fmt.Sprintf("%s-%s-%s", key.GiantSwarmNamespace(), latestEntry.Name, latestEntry.Version)
 
 		o := func() error {
 			entryCR, err = config.K8sClients.G8sClient().ApplicationV1alpha1().AppCatalogEntries(metav1.NamespaceDefault).Get(ctx, appCatalogEntryName, metav1.GetOptions{})

--- a/integration/test/watcher/configmap/configmap_test.go
+++ b/integration/test/watcher/configmap/configmap_test.go
@@ -41,24 +41,24 @@ func TestWatchingConfigMap(t *testing.T) {
 	var err error
 
 	{
-		config.Logger.Debugf(ctx, "creating configmap %#q in namespace %#q", key.AppCatalogConfigMapName(), key.Namespace())
+		config.Logger.Debugf(ctx, "creating configmap %#q in namespace %#q", key.AppCatalogConfigMapName(), key.GiantSwarmNamespace())
 
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      key.AppCatalogConfigMapName(),
-				Namespace: key.Namespace(),
+				Namespace: key.GiantSwarmNamespace(),
 			},
 			Data: map[string]string{
 				"values": "",
 			},
 		}
 
-		_, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.Namespace()).Create(ctx, cm, metav1.CreateOptions{})
+		_, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.GiantSwarmNamespace()).Create(ctx, cm, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.Debugf(ctx, "created configmap %#q in namespace %#q", key.AppCatalogConfigMapName(), key.Namespace())
+		config.Logger.Debugf(ctx, "created configmap %#q in namespace %#q", key.AppCatalogConfigMapName(), key.GiantSwarmNamespace())
 	}
 
 	{
@@ -75,7 +75,7 @@ func TestWatchingConfigMap(t *testing.T) {
 				Config: v1alpha1.AppCatalogSpecConfig{
 					ConfigMap: v1alpha1.AppCatalogSpecConfigConfigMap{
 						Name:      key.AppCatalogConfigMapName(),
-						Namespace: key.Namespace(),
+						Namespace: key.GiantSwarmNamespace(),
 					},
 				},
 				Description: key.DefaultCatalogName(),
@@ -95,24 +95,24 @@ func TestWatchingConfigMap(t *testing.T) {
 	}
 
 	{
-		config.Logger.Debugf(ctx, "creating configmap %#q in namespace %#q", key.UserConfigMapName(), key.Namespace())
+		config.Logger.Debugf(ctx, "creating configmap %#q in namespace %#q", key.UserConfigMapName(), key.GiantSwarmNamespace())
 
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      key.UserConfigMapName(),
-				Namespace: key.Namespace(),
+				Namespace: key.GiantSwarmNamespace(),
 			},
 			Data: map[string]string{
 				"values": "",
 			},
 		}
 
-		_, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.Namespace()).Create(ctx, cm, metav1.CreateOptions{})
+		_, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.GiantSwarmNamespace()).Create(ctx, cm, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
-		config.Logger.Debugf(ctx, "created configmap %#q in namespace %#q", key.UserConfigMapName(), key.Namespace())
+		config.Logger.Debugf(ctx, "created configmap %#q in namespace %#q", key.UserConfigMapName(), key.GiantSwarmNamespace())
 	}
 
 	{
@@ -121,7 +121,7 @@ func TestWatchingConfigMap(t *testing.T) {
 		appCR := &v1alpha1.App{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      key.TestAppName(),
-				Namespace: key.Namespace(),
+				Namespace: key.GiantSwarmNamespace(),
 				Labels: map[string]string{
 					label.AppOperatorVersion: key.UniqueAppVersion(),
 				},
@@ -132,18 +132,18 @@ func TestWatchingConfigMap(t *testing.T) {
 					InCluster: true,
 				},
 				Name:      key.TestAppName(),
-				Namespace: key.Namespace(),
+				Namespace: key.GiantSwarmNamespace(),
 				UserConfig: v1alpha1.AppSpecUserConfig{
 					ConfigMap: v1alpha1.AppSpecUserConfigConfigMap{
 						Name:      key.UserConfigMapName(),
-						Namespace: key.Namespace(),
+						Namespace: key.GiantSwarmNamespace(),
 					},
 				},
 				Version: "0.1.0",
 			},
 		}
 
-		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Create(ctx, appCR, metav1.CreateOptions{})
+		_, err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.GiantSwarmNamespace()).Create(ctx, appCR, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -155,7 +155,7 @@ func TestWatchingConfigMap(t *testing.T) {
 		config.Logger.Debugf(ctx, "waiting until user configmap is labelled")
 
 		o := func() error {
-			cm, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.Namespace()).Get(ctx, key.UserConfigMapName(), metav1.GetOptions{})
+			cm, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.GiantSwarmNamespace()).Get(ctx, key.UserConfigMapName(), metav1.GetOptions{})
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -184,7 +184,7 @@ func TestWatchingConfigMap(t *testing.T) {
 		config.Logger.Debugf(ctx, "waiting until appcatalog configmap is labelled")
 
 		o := func() error {
-			cm, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.Namespace()).Get(ctx, key.AppCatalogConfigMapName(), metav1.GetOptions{})
+			cm, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.GiantSwarmNamespace()).Get(ctx, key.AppCatalogConfigMapName(), metav1.GetOptions{})
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -211,22 +211,22 @@ func TestWatchingConfigMap(t *testing.T) {
 
 	var updatedResourceVersion string
 	{
-		config.Logger.Debugf(ctx, "updating values in configmap %#q in namespace %#q", key.UserConfigMapName(), key.Namespace())
+		config.Logger.Debugf(ctx, "updating values in configmap %#q in namespace %#q", key.UserConfigMapName(), key.GiantSwarmNamespace())
 
-		cm, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.Namespace()).Get(ctx, key.UserConfigMapName(), metav1.GetOptions{})
+		cm, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.GiantSwarmNamespace()).Get(ctx, key.UserConfigMapName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
 		cm.Data["values"] = "test: userconfigmap"
-		updatedCM, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.Namespace()).Update(ctx, cm, metav1.UpdateOptions{})
+		updatedCM, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.GiantSwarmNamespace()).Update(ctx, cm, metav1.UpdateOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
 		updatedResourceVersion = updatedCM.GetResourceVersion()
 
-		config.Logger.Debugf(ctx, "updated values in configmap %#q in namespace %#q", key.UserConfigMapName(), key.Namespace())
+		config.Logger.Debugf(ctx, "updated values in configmap %#q in namespace %#q", key.UserConfigMapName(), key.GiantSwarmNamespace())
 	}
 
 	versionAnnotation := fmt.Sprintf("%s/%s", annotation.AppOperatorPrefix, annotation.LatestConfigMapVersion)
@@ -235,7 +235,7 @@ func TestWatchingConfigMap(t *testing.T) {
 		config.Logger.Debugf(ctx, "waiting until app CR is annotated with user configmap's resourceVersion")
 
 		o := func() error {
-			cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
+			cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.GiantSwarmNamespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -263,29 +263,29 @@ func TestWatchingConfigMap(t *testing.T) {
 	}
 
 	{
-		config.Logger.Debugf(ctx, "editing configmap %#q in namespace %#q", key.AppCatalogConfigMapName(), key.Namespace())
+		config.Logger.Debugf(ctx, "editing configmap %#q in namespace %#q", key.AppCatalogConfigMapName(), key.GiantSwarmNamespace())
 
-		cm, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.Namespace()).Get(ctx, key.AppCatalogConfigMapName(), metav1.GetOptions{})
+		cm, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.GiantSwarmNamespace()).Get(ctx, key.AppCatalogConfigMapName(), metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
 		cm.Data["values"] = "test: appcatalogConfigmap"
-		updatedCM, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.Namespace()).Update(ctx, cm, metav1.UpdateOptions{})
+		updatedCM, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.GiantSwarmNamespace()).Update(ctx, cm, metav1.UpdateOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
 
 		updatedResourceVersion = updatedCM.GetResourceVersion()
 
-		config.Logger.Debugf(ctx, "edited configmap %#q in namespace %#q", key.UserConfigMapName(), key.Namespace())
+		config.Logger.Debugf(ctx, "edited configmap %#q in namespace %#q", key.UserConfigMapName(), key.GiantSwarmNamespace())
 	}
 
 	{
 		config.Logger.Debugf(ctx, "waiting until app CR annotate by appcatalog configmap's resourceVersion")
 
 		o := func() error {
-			cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
+			cr, err := config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.GiantSwarmNamespace()).Get(ctx, key.TestAppName(), metav1.GetOptions{})
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -315,7 +315,7 @@ func TestWatchingConfigMap(t *testing.T) {
 	{
 		config.Logger.Debugf(ctx, "deleting app CR %#q", key.TestAppName())
 
-		err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.Namespace()).Delete(ctx, key.TestAppName(), metav1.DeleteOptions{})
+		err = config.K8sClients.G8sClient().ApplicationV1alpha1().Apps(key.GiantSwarmNamespace()).Delete(ctx, key.TestAppName(), metav1.DeleteOptions{})
 		if err != nil {
 			t.Fatalf("expected %#v got %#v", nil, err)
 		}
@@ -327,7 +327,7 @@ func TestWatchingConfigMap(t *testing.T) {
 		config.Logger.Debugf(ctx, "waiting until watching label is deleted")
 
 		o := func() error {
-			cm, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.Namespace()).Get(ctx, key.UserConfigMapName(), metav1.GetOptions{})
+			cm, err := config.K8sClients.K8sClient().CoreV1().ConfigMaps(key.GiantSwarmNamespace()).Get(ctx, key.UserConfigMapName(), metav1.GetOptions{})
 			if err != nil {
 				return microerror.Mask(err)
 			}


### PR DESCRIPTION
This is to clean up the diff when we merge the v4-dev branch into master. Will go with a ping.