### PR TITLE
Delete resources if app CR uses in cluster

### DIFF
--- a/service/controller/app/resource/appnamespace/delete.go
+++ b/service/controller/app/resource/appnamespace/delete.go
@@ -15,6 +15,12 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	// If the app CR is in-cluster then we need to delete the resources even if
+	// the namespace is being deleted.
+	if key.InCluster(cr) {
+		return nil
+	}
+
 	err = r.addNamespaceStatusToContext(ctx, cr)
 	if err != nil {
 		return microerror.Mask(err)


### PR DESCRIPTION
The appnamespace resource checks if the namespace is being deleted and adds a flag to the controller context.

We do this for workload clusters as the cluster is being deleted. But for the app-operator app CR we need to delete these resources.