### PR TITLE
Use backoff in chart CR watcher to wait until kubeconfig exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Use backoff in chart CR watcher to wait until kubeconfig secret exists.
+
 ## [4.0.0] - 2021-02-23
 
 ### Added

--- a/service/watcher/chartstatus/chartstatus.go
+++ b/service/watcher/chartstatus/chartstatus.go
@@ -85,7 +85,7 @@ func (c *ChartStatusWatcher) watchChartStatus(ctx context.Context) {
 		// check we can connect and wait with a backoff if it is unavailable.
 		err = c.waitForAvailableConnection(ctx, g8sClient)
 		if err != nil {
-			c.logger.Errorf(ctx, err, "failed to get active g8sclient")
+			c.logger.Errorf(ctx, err, "failed to get available connection")
 			continue
 		}
 

--- a/service/watcher/chartstatus/chartstatus.go
+++ b/service/watcher/chartstatus/chartstatus.go
@@ -83,7 +83,7 @@ func (c *ChartStatusWatcher) watchChartStatus(ctx context.Context) {
 
 		// The connection to the cluster will sometimes be down. So we
 		// check we can connect and wait with a backoff if it is unavailable.
-		err = c.waitForAvailableG8sClient(ctx, g8sClient)
+		err = c.waitForAvailableConnection(ctx, g8sClient)
 		if err != nil {
 			c.logger.Errorf(ctx, err, "failed to get active g8sclient")
 			continue

--- a/service/watcher/chartstatus/g8sclient.go
+++ b/service/watcher/chartstatus/g8sclient.go
@@ -72,10 +72,10 @@ func (c *ChartStatusWatcher) waitForG8sClient(ctx context.Context) (versioned.In
 	return g8sClient, nil
 }
 
-// waitForAvailableG8sClient ensures we can connect to the target cluster if it
+// waitForAvailableConnection ensures we can connect to the target cluster if it
 // is remote. Sometimes the connection will be unavailable so we list all chart
 // CRs to confirm the connection is active.
-func (c *ChartStatusWatcher) waitForAvailableG8sClient(ctx context.Context, g8sClient versioned.Interface) error {
+func (c *ChartStatusWatcher) waitForAvailableConnection(ctx context.Context, g8sClient versioned.Interface) error {
 	var err error
 
 	o := func() error {


### PR DESCRIPTION
Towards giantswarm/giantswarm#14163

When testing on ginger yesterday there was a problem creating the kubeconfig secret. This adds a backoff to reduce the number of requests we make to the API server.

## Checklist

- [x] Update changelog in CHANGELOG.md.