### PR TITLE
Drop k8sclient from server pkg

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,9 +107,8 @@ func mainWithError() (err error) {
 		var newServer microserver.Server
 		{
 			c := server.Config{
-				K8sClient: k8sClient,
-				Logger:    newLogger,
-				Service:   newService,
+				Logger:  newLogger,
+				Service: newService,
 
 				Viper: v,
 			}

--- a/server/endpoint/endpoint.go
+++ b/server/endpoint/endpoint.go
@@ -1,7 +1,6 @@
 package endpoint
 
 import (
-	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/microendpoint/endpoint/healthz"
 	"github.com/giantswarm/microendpoint/endpoint/version"
 	"github.com/giantswarm/microerror"
@@ -13,9 +12,8 @@ import (
 // Config represents the configuration used to construct an endpoint.
 type Config struct {
 	// Dependencies
-	K8sClient k8sclient.Interface
-	Logger    micrologger.Logger
-	Service   *service.Service
+	Logger  micrologger.Logger
+	Service *service.Service
 }
 
 // Endpoint is the endpoint collection.
@@ -26,9 +24,6 @@ type Endpoint struct {
 
 // New creates a new endpoint with given configuration.
 func New(config Config) (*Endpoint, error) {
-	if config.K8sClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
-	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	microserver "github.com/giantswarm/microkit/server"
 	"github.com/giantswarm/micrologger"
@@ -18,9 +17,8 @@ import (
 
 // Config represents the configuration used to construct server object.
 type Config struct {
-	K8sClient k8sclient.Interface
-	Logger    micrologger.Logger
-	Service   *service.Service
+	Logger  micrologger.Logger
+	Service *service.Service
 
 	Viper            *viper.Viper
 	WebhookAuthToken string
@@ -30,9 +28,6 @@ type Config struct {
 func New(config Config) (microserver.Server, error) {
 	var err error
 
-	if config.K8sClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
-	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -47,9 +42,8 @@ func New(config Config) (microserver.Server, error) {
 	var endpointCollection *endpoint.Endpoint
 	{
 		c := endpoint.Config{
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
-			Service:   config.Service,
+			Logger:  config.Logger,
+			Service: config.Service,
 		}
 
 		endpointCollection, err = endpoint.New(c)


### PR DESCRIPTION
We are not using k8sclient from the server anymore after the webhook deletion. 

## Checklist

- [ ] Update changelog in CHANGELOG.md.