### PR TITLE
Set latest label to false in appcatalogentry test

### DIFF
--- a/integration/test/appcatalog/appcatalogentry/app_catalog_entry_test.go
+++ b/integration/test/appcatalog/appcatalogentry/app_catalog_entry_test.go
@@ -99,7 +99,7 @@ func TestAppCatalogEntry(t *testing.T) {
 
 	{
 		// Set latest label to false to stop the test from flapping. This is
-		// because the latest release may not be the latet according to semver.
+		// because the latest release may not be the latest according to semver.
 		entryCR.Labels[pkglabel.Latest] = "false"
 
 		expectedLabels := map[string]string{

--- a/integration/test/appcatalog/appcatalogentry/app_catalog_entry_test.go
+++ b/integration/test/appcatalog/appcatalogentry/app_catalog_entry_test.go
@@ -98,6 +98,10 @@ func TestAppCatalogEntry(t *testing.T) {
 	}
 
 	{
+		// Set latest label to false to stop the test from flapping. This is
+		// because the latest release may not be the latet according to semver.
+		entryCR.Labels[pkglabel.Latest] = "false"
+
 		expectedLabels := map[string]string{
 			label.AppKubernetesName:    "prometheus-operator-app",
 			label.AppKubernetesVersion: latestEntry.Version,


### PR DESCRIPTION
Fix to make the appcatalogentry test more reliable.
