### PR TITLE
Create AppCatalog CRs for compatibility 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
-- Create `AppCatalog` CRs out of `Catalog` CRs in the cluster namespace for compatibility.
+- Create `AppCatalog` CRs from `Catalog` CRs for compatibility with existing app-operator releases.
 - Prepare helm values to configuration management.
 - Use `Catalog` CRs in `App` controller.
 - Reconcile to `Catalog` CRs instead of `AppCatalog`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
+- Create `AppCatalog` CRs out of `Catalog` CRs in the cluster namespace for compatibility.
 - Prepare helm values to configuration management.
 - Use `Catalog` CRs in `App` controller.
 - Reconcile to `Catalog` CRs instead of `AppCatalog`.

--- a/service/controller/catalog/resource/appcatalogsync/create.go
+++ b/service/controller/catalog/resource/appcatalogsync/create.go
@@ -13,7 +13,7 @@ import (
 // EnsureCreated ensures appcatalog CRs are created for compatibility with catalog CRs
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	if !r.uniqueApp {
-		// Return early. Only unique instance manages appcatalogentry CRs.
+		// Return early. Only unique instance manages appcatalog CRs.
 		return nil
 	}
 

--- a/service/controller/catalog/resource/appcatalogsync/create.go
+++ b/service/controller/catalog/resource/appcatalogsync/create.go
@@ -1,0 +1,56 @@
+package appcatalogsync
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/app/v5/pkg/key"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EnsureCreated ensures appcatalog CRs are created for compatibility with catalog CRs
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	if !r.uniqueApp {
+		// Return early. Only unique instance manages appcatalogentry CRs.
+		return nil
+	}
+
+	cr, err := key.ToCatalog(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if namespace := cr.GetNamespace(); namespace == metav1.NamespaceDefault || namespace == "giantswarm" {
+		// Return early. No need to reconcile catalog CRs in default namespace or giantswarm namespace.
+		return nil
+	}
+
+	appCatalogCR := &v1alpha1.AppCatalog{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        cr.GetName(),
+			Annotations: cr.GetAnnotations(),
+			Labels:      cr.GetLabels(),
+		},
+		Spec: v1alpha1.AppCatalogSpec{
+			Description: cr.Spec.Description,
+			Title:       key.CatalogTitle(cr),
+			Storage: v1alpha1.AppCatalogSpecStorage{
+				Type: "helm",
+				URL:  key.CatalogStorageURL(cr),
+			},
+		},
+	}
+	_, err = r.k8sClient.G8sClient().ApplicationV1alpha1().AppCatalogs().Create(ctx, appCatalogCR, metav1.CreateOptions{})
+	if apierrors.IsAlreadyExists(err) {
+		// no-op
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.Debugf(ctx, "created appCatalog %#q for compatibility", cr.GetName())
+
+	return nil
+}

--- a/service/controller/catalog/resource/appcatalogsync/delete.go
+++ b/service/controller/catalog/resource/appcatalogsync/delete.go
@@ -12,7 +12,7 @@ import (
 // EnsureDeleted ensures appcatalog CRs are deleted when catalog CRs are deleted.
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	if !r.uniqueApp {
-		// Return early. Only unique instance manages appcatalogentry CRs.
+		// Return early. Only unique instance manages appcatalog CRs.
 		return nil
 	}
 

--- a/service/controller/catalog/resource/appcatalogsync/delete.go
+++ b/service/controller/catalog/resource/appcatalogsync/delete.go
@@ -26,6 +26,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
+	_, err = r.k8sClient.G8sClient().ApplicationV1alpha1().AppCatalogs().Get(ctx, cr.GetName(), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		//no-op
+		return nil
+	}
+
+	r.logger.Debugf(ctx, "deleting appCatalog %#q which had been created for compatibility", cr.GetName())
+
 	err = r.k8sClient.G8sClient().ApplicationV1alpha1().AppCatalogs().Delete(ctx, cr.GetName(), metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// no-op

--- a/service/controller/catalog/resource/appcatalogsync/delete.go
+++ b/service/controller/catalog/resource/appcatalogsync/delete.go
@@ -1,0 +1,40 @@
+package appcatalogsync
+
+import (
+	"context"
+
+	"github.com/giantswarm/app/v5/pkg/key"
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EnsureDeleted ensures appcatalog CRs are deleted when catalog CRs are deleted.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	if !r.uniqueApp {
+		// Return early. Only unique instance manages appcatalogentry CRs.
+		return nil
+	}
+
+	cr, err := key.ToCatalog(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if namespace := cr.GetNamespace(); namespace == metav1.NamespaceDefault || namespace == "giantswarm" {
+		// Return early. No need to reconcile catalog CRs in default namespace or giantswarm namespace.
+		return nil
+	}
+
+	err = r.k8sClient.G8sClient().ApplicationV1alpha1().AppCatalogs().Delete(ctx, cr.GetName(), metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		// no-op
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.Debugf(ctx, "deleted appCatalog %#q which had been created for compatibility", cr.GetName())
+
+	return nil
+}

--- a/service/controller/catalog/resource/appcatalogsync/error.go
+++ b/service/controller/catalog/resource/appcatalogsync/error.go
@@ -1,0 +1,12 @@
+package appcatalogsync
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/catalog/resource/appcatalogsync/resource.go
+++ b/service/controller/catalog/resource/appcatalogsync/resource.go
@@ -55,9 +55,6 @@ func equals(a, b *v1alpha1.AppCatalog) bool {
 	if a.Name != b.Name {
 		return false
 	}
-	if a.Namespace != b.Namespace {
-		return false
-	}
 	if !reflect.DeepEqual(a.Annotations, b.Annotations) {
 		return false
 	}

--- a/service/controller/catalog/resource/appcatalogsync/resource.go
+++ b/service/controller/catalog/resource/appcatalogsync/resource.go
@@ -1,6 +1,9 @@
 package appcatalogsync
 
 import (
+	"reflect"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -44,4 +47,26 @@ func New(config Config) (*Resource, error) {
 
 func (r Resource) Name() string {
 	return Name
+}
+
+// equals asseses the equality of AppCatalog with regards to distinguishing
+// fields.
+func equals(a, b *v1alpha1.AppCatalog) bool {
+	if a.Name != b.Name {
+		return false
+	}
+	if a.Namespace != b.Namespace {
+		return false
+	}
+	if !reflect.DeepEqual(a.Annotations, b.Annotations) {
+		return false
+	}
+	if !reflect.DeepEqual(a.Labels, b.Labels) {
+		return false
+	}
+	if !reflect.DeepEqual(a.Spec, b.Spec) {
+		return false
+	}
+
+	return true
 }

--- a/service/controller/catalog/resource/appcatalogsync/resource.go
+++ b/service/controller/catalog/resource/appcatalogsync/resource.go
@@ -1,0 +1,48 @@
+package appcatalogsync
+
+import (
+	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "appcatalogsync"
+)
+
+type Config struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+
+	UniqueApp bool
+}
+
+type Resource struct {
+	k8sClient k8sclient.Interface
+	logger    micrologger.Logger
+
+	uniqueApp bool
+}
+
+// New creates a new configured tcnamespace resource.
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+
+		uniqueApp: config.UniqueApp,
+	}
+
+	return r, nil
+}
+
+func (r Resource) Name() string {
+	return Name
+}

--- a/service/controller/catalog/resource/appcatalogsync/resource.go
+++ b/service/controller/catalog/resource/appcatalogsync/resource.go
@@ -24,7 +24,6 @@ type Resource struct {
 	uniqueApp bool
 }
 
-// New creates a new configured tcnamespace resource.
 func New(config Config) (*Resource, error) {
 	if config.K8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)

--- a/service/controller/catalog/resources.go
+++ b/service/controller/catalog/resources.go
@@ -9,6 +9,7 @@ import (
 	"github.com/giantswarm/operatorkit/v5/pkg/resource/wrapper/retryresource"
 
 	"github.com/giantswarm/app-operator/v4/service/controller/catalog/resource/appcatalogentry"
+	"github.com/giantswarm/app-operator/v4/service/controller/catalog/resource/appcatalogsync"
 )
 
 type catalogResourcesConfig struct {
@@ -46,8 +47,24 @@ func newCatalogResources(config catalogResourcesConfig) ([]resource.Interface, e
 		}
 	}
 
+	var appCatalogSyncResource resource.Interface
+	{
+		c := appcatalogsync.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			UniqueApp: config.UniqueApp,
+		}
+
+		appCatalogSyncResource, err = appcatalogsync.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		appCatalogEntryResource,
+		appCatalogSyncResource,
 	}
 
 	{


### PR DESCRIPTION
No issue yet but we briefly talked about how to create appcatalog CRs for compatibility with catalog CRs and we decided to create `appcatalogsync` resource as our solution.

https://gigantic.slack.com/archives/C76JX6YLQ/p1624451154111100
## Checklist

- [x] Update changelog in CHANGELOG.md.