### PR TITLE
Fix a log in catalog resource

### DIFF
--- a/service/controller/app/resource/catalog/resource.go
+++ b/service/controller/app/resource/catalog/resource.go
@@ -76,9 +76,8 @@ func (r *Resource) getCatalogForApp(ctx context.Context, customResource v1alpha1
 	}
 
 	var catalog *v1alpha1.Catalog
-	var namespace string
-	for _, namespace := range namespaces {
-		catalog, err = r.g8sClient.ApplicationV1alpha1().Catalogs(namespace).Get(ctx, catalogName, metav1.GetOptions{})
+	for _, ns := range namespaces {
+		catalog, err = r.g8sClient.ApplicationV1alpha1().Catalogs(ns).Get(ctx, catalogName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			// no-op
 			continue
@@ -92,7 +91,7 @@ func (r *Resource) getCatalogForApp(ctx context.Context, customResource v1alpha1
 		return microerror.Maskf(notFoundError, "catalog %#q", catalogName)
 	}
 
-	r.logger.Debugf(ctx, "found catalog %#q in namespace %#q", catalogName, namespace)
+	r.logger.Debugf(ctx, "found catalog %#q in namespace %#q", catalogName, catalog.GetNamespace())
 	cc.Catalog = *catalog
 
 	return nil


### PR DESCRIPTION
During my testing on ginger, I found out app-operator logs wrong messages as below. It didn't print the namespace of apps correctly.  

```
D 07/05 08:20:02 giantswarm/aws-operator-10.2.0 catalog looking for catalog `control-plane-catalog` | app-operator/v4/service/controller/app/resource/catalog/resource.go:67 | controller=app-operator-app | event=update | loop=91 | version=268726590D 07/05 08:20:02 giantswarm/aws-operator-10.2.0 catalog found catalog `control-plane-catalog` in namespace `` | app-operator/v4/service/controller/app/resource/catalog/resource.go:95 | controller=app-operator-app | event=update | loop=91 | version=268726590
```

## Checklist

~- [ ] Update changelog in CHANGELOG.md.~ No need to update the changelog.