### PR TITLE
Allow usage of chart-operator PSP for bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow usage of chart-operator PSP so it can be bootstrapped.
+
 ## [5.7.3] - 2022-02-28
 
 ### Fixed

--- a/helm/app-operator/templates/rbac.yaml
+++ b/helm/app-operator/templates/rbac.yaml
@@ -110,6 +110,7 @@ rules:
     - use
   resourceNames:
     - {{ include  "resource.psp.name" . }}
+    - chart-operator-psp
 - apiGroups:
     - rbac.authorization.k8s.io
   resources:


### PR DESCRIPTION
Follow up to https://github.com/giantswarm/app-operator/pull/938

Without this app-operator can't bootstrap chart-operator. It fails with

```
E 03/01 12:41:52 giantswarm/chart-operator failed to reconcile | operatorkit/v6/pkg/controller/controller.go:322 | controller=app-operator-app | event=update | loop=10057 | version=283795977
	/go/pkg/mod/github.com/giantswarm/operatorkit/v6@v6.1.0/pkg/controller/controller.go:528
	/go/pkg/mod/github.com/giantswarm/operatorkit/v6@v6.1.0/pkg/controller/controller.go:563
	/go/pkg/mod/github.com/giantswarm/operatorkit/v6@v6.1.0/pkg/resource/wrapper/metricsresource/basic_resource.go:43
	/go/pkg/mod/github.com/giantswarm/operatorkit/v6@v6.1.0/pkg/resource/wrapper/retryresource/basic_resource.go:64
	/go/pkg/mod/github.com/giantswarm/backoff@v1.0.0/retry.go:23
	/go/pkg/mod/github.com/giantswarm/operatorkit/v6@v6.1.0/pkg/resource/wrapper/retryresource/basic_resource.go:52
	/root/project/service/controller/app/resource/chartoperator/create.go:116
	/root/project/service/controller/app/resource/chartoperator/resource.go:284
	/go/pkg/mod/github.com/giantswarm/helmclient/v4@v4.9.0/pkg/helmclient/update.go:27
	/go/pkg/mod/github.com/giantswarm/helmclient/v4@v4.9.0/pkg/helmclient/update.go:53
	unknown: failed to create resource: clusterroles.rbac.authorization.k8s.io "chart-operator-psp" is forbidden: user "system:serviceaccount:giantswarm:app-operator" (groups=["system:serviceaccounts" "system:serviceaccounts:giantswarm" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["policy"], Resources:["podsecuritypolicies"], ResourceNames:["chart-operator-psp"], Verbs:["use"]}
```

## Checklist

- [x] Update changelog in CHANGELOG.md.