### PR TITLE
Continue processing AppCatalogEntry CRs if error occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Continue processing `AppCatalogEntry` CRs if an error occurs.
+
 ## [5.7.5] - 2022-03-01
 
 ### Fixed

--- a/service/controller/catalog/resource/appcatalogentry/create.go
+++ b/service/controller/catalog/resource/appcatalogentry/create.go
@@ -58,7 +58,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	var created, updated, deleted int
+	var created, updated, deleted, errored int
 
 	r.logger.Debugf(ctx, "finding out changes to appcatalogentries for catalog %#q", cr.Name)
 
@@ -90,14 +90,18 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("appCatalogEntry %#q has to be updated", currentEntryCR.Name), "diff", fmt.Sprintf("(-current +desired):\n%s", diff))
 			err := r.updateAppCatalogEntry(ctx, desiredEntryCR)
 			if err != nil {
-				return microerror.Mask(err)
+				// Log error but continue processing other CRs.
+				r.logger.Errorf(ctx, err, "failed to create appCatalogEntry %#q", currentEntryCR.Name)
+				errored++
 			}
 
 			updated++
 		} else {
 			err := r.createAppCatalogEntry(ctx, desiredEntryCR)
 			if err != nil {
-				return microerror.Mask(err)
+				// Log error but continue processing other CRs.
+				r.logger.Errorf(ctx, err, "failed to update appCatalogEntry %#q", currentEntryCR.Name)
+				errored++
 			}
 
 			created++
@@ -111,7 +115,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		if !ok {
 			err := r.deleteAppCatalogEntry(ctx, currentEntryCR)
 			if err != nil {
-				return microerror.Mask(err)
+				// Log error but continue processing other CRs.
+				r.logger.Errorf(ctx, err, "failed to update appCatalogEntry %#q", currentEntryCR.Name)
+				errored++
 			}
 
 			deleted++
@@ -119,6 +125,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	r.logger.Debugf(ctx, "created %d updated %d deleted %d appcatalogentries for catalog %#q", created, updated, deleted, cr.Name)
+	if errored > 0 {
+		r.logger.Debugf(ctx, "failed to process %d appcatalogentries for catalog %#q", errored, cr.Name)
+	}
 
 	return nil
 }

--- a/service/controller/catalog/resource/appcatalogentry/create.go
+++ b/service/controller/catalog/resource/appcatalogentry/create.go
@@ -91,7 +91,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			err := r.updateAppCatalogEntry(ctx, desiredEntryCR)
 			if err != nil {
 				// Log error but continue processing other CRs.
-				r.logger.Errorf(ctx, err, "failed to create appCatalogEntry %#q", currentEntryCR.Name)
+				r.logger.Errorf(ctx, err, "failed to update appCatalogEntry %#q", desiredEntryCR.Name)
 				errored++
 			}
 
@@ -100,7 +100,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			err := r.createAppCatalogEntry(ctx, desiredEntryCR)
 			if err != nil {
 				// Log error but continue processing other CRs.
-				r.logger.Errorf(ctx, err, "failed to update appCatalogEntry %#q", currentEntryCR.Name)
+				r.logger.Errorf(ctx, err, "failed to create appCatalogEntry %#q", desiredEntryCR.Name)
 				errored++
 			}
 
@@ -116,7 +116,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			err := r.deleteAppCatalogEntry(ctx, currentEntryCR)
 			if err != nil {
 				// Log error but continue processing other CRs.
-				r.logger.Errorf(ctx, err, "failed to update appCatalogEntry %#q", currentEntryCR.Name)
+				r.logger.Errorf(ctx, err, "failed to delete appCatalogEntry %#q", currentEntryCR.Name)
 				errored++
 			}
 


### PR DESCRIPTION
Currently if processing an AppCatalogEntry CR fails we don't process the rest of the entries in the index.yaml.

This happened due to the cluster-openstack app being in the giantswarm catalog. The validation rules got fixed but it could happen again.

Now we just log the error.

```
2022-03-09T16:54:21.066171239Z stdout F {"caller":"github.com/giantswarm/app-operator/v5/service/controller/catalog/resource/appcatalogentry/create.go:103","controller":"app-operator-catalog","event":"update","level":"error","loop":"1","message":"failed to create appCatalogEntry `giantswarm-default-apps-openstack-0.2.0`","object":"default/giantswarm","resource":"appcatalogentry","stack":{"annotation":"AppCatalogEntry.application.giantswarm.io \"giantswarm-default-apps-openstack-0.2.0\" is invalid: spec.restrictions.compatibleProviders: Unsupported value: \"openstack\": supported values: \"aws\", \"azure\", \"kvm\"","kind":"unknown","stack":[{"file":"/root/project/service/controller/catalog/resource/appcatalogentry/create.go","line":143}]},"time":"2022-03-09T16:54:21.066087+00:00","version":"824"}
```

We also output how many records failed.

```
2022-03-09T16:54:21.108213482Z stdout F {"caller":"github.com/giantswarm/app-operator/v5/service/controller/catalog/resource/appcatalogentry/create.go:127","controller":"app-operator-catalog","event":"update","level":"debug","loop":"1","message":"created 127 updated 0 deleted 0 appcatalogentries for catalog `giantswarm`","object":"default/giantswarm","resource":"appcatalogentry","time":"2022-03-09T16:54:21.108162+00:00","version":"824"}
2022-03-09T16:54:21.108317625Z stdout F {"caller":"github.com/giantswarm/app-operator/v5/service/controller/catalog/resource/appcatalogentry/create.go:129","controller":"app-operator-catalog","event":"update","level":"debug","loop":"1","message":"failed to process 5 appcatalogentries for catalog `giantswarm`","object":"default/giantswarm","resource":"appcatalogentry","time":"2022-03-09T16:54:21.108249+00:00","version":"824"}
```

## Checklist

- [x] Update changelog in CHANGELOG.md.