### PR TITLE
Default dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use `Default` dnsPolicy in order to make `AppOperator` work even on clusters with no coredns.
+
 ### Added
 
 - Add support for relative URLs in catalog indexes.

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       annotations:
         app.giantswarm.io/config-checksum: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
     spec:
+      dnsPolicy: Default
       volumes:
       - name: {{ include "name" . }}-configmap
         configMap:


### PR DESCRIPTION
If coredns is installed as an app (that is the case in management clusters) there is a chicken-egg problem:
app operator needs coredns to resolve catalog URLs' hostnames, coredns needs app operator to be installed.

IF and this is an IF I ask to the reviewers app operator does NOT need to resolve cluster-internal names, than with this PR we solve this chicken-egg problem

## Checklist

- [x] Update changelog in CHANGELOG.md.