### PR TITLE
Generate tarball URLs for internal catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Fixed
 
 - Continue processing `AppCatalogEntry` CRs if an error occurs.
+- For internal catalogs generate tarball URLs instead of checking `index.yaml`
+to prevent chicken egg problems in new clusters. 
 
 ## [5.7.5] - 2022-03-01
 


### PR DESCRIPTION
To avoid chicken egg problems in new management clusters we generate the tarball URL for internal catalogs.

See https://gigantic.slack.com/archives/C02GDJJ68Q1/p1646929699022069

## Checklist

- [x] Update changelog in CHANGELOG.md.