### PR TITLE
Add missing permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing permissions for `apps/deployments`.
+
 ## [5.10.1] - 2022-05-18
 
 ### Fixed

--- a/helm/app-operator/templates/rbac.yaml
+++ b/helm/app-operator/templates/rbac.yaml
@@ -146,6 +146,12 @@ rules:
   verbs:
     - "*"
 - apiGroups:
+    - apps
+  resources:
+    - deployments
+  verbs:
+    - "*"
+- apiGroups:
     - ""
   resources:
     - events


### PR DESCRIPTION
## Description

Fixes below error.

```sh
E 05/18 11:40:38 giantswarm/chart-operator failed to reconcile | operatorkit/v6/pkg/controller/controller.go:322 | controller=app-operator-app | event=update | loop=1251 | version=572802353
	/go/pkg/mod/github.com/giantswarm/operatorkit/v6@v6.1.0/pkg/controller/controller.go:528
	/go/pkg/mod/github.com/giantswarm/operatorkit/v6@v6.1.0/pkg/controller/controller.go:563
	/go/pkg/mod/github.com/giantswarm/operatorkit/v6@v6.1.0/pkg/resource/wrapper/metricsresource/basic_resource.go:43
	/go/pkg/mod/github.com/giantswarm/operatorkit/v6@v6.1.0/pkg/resource/wrapper/retryresource/basic_resource.go:64
	/go/pkg/mod/github.com/giantswarm/backoff@v1.0.0/retry.go:23
	/go/pkg/mod/github.com/giantswarm/operatorkit/v6@v6.1.0/pkg/resource/wrapper/retryresource/basic_resource.go:52
	/root/project/service/controller/app/resource/chartoperator/create.go:55
	unknown: deployments.apps "chart-operator" is forbidden: User "system:serviceaccount:giantswarm:app-operator" cannot get resource "deployments" in API group "apps" in the namespace "giantswarm"
```

## Checklist

- [x] Update changelog in CHANGELOG.md.
