### PR TITLE
Change VPA settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.swp
 
 # build result
-app-operator
+/app-operator
 app-operator-*
 
 # don't apply earlier restrictions under vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Only set resource limits on the deployment when the VPA is not available or disabled
+- Increase min / max resource limits on VPA
+
 ## [5.10.2] - 2022-05-18
 
 ### Fixed

--- a/helm/app-operator/templates/_resource.tpl
+++ b/helm/app-operator/templates/_resource.tpl
@@ -39,13 +39,26 @@ CR version of 0.0.0.
 {{- end -}}
 
 {{/*
+
+*/}}
+{{- define "resource.vpa.enabled" -}}
+{{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") (.Values.verticalPodAutoscaler.enabled) }}true{{ else }}false{{ end }}
+{{- end -}}
+
+{{/*
 The unique deployment in the management cluster requires more resources than
 the per workload cluster instances.
 */}}
 {{- define "resource.deployment.resources" -}}
 {{- if eq (include "resource.app.unique" .) "true" -}}
-{{ toYaml .Values.deployment.management }}
+{{ toYaml .Values.deployment.management.requests }}
+{{- if eq (include "resource.vpa.enabled" .) "false" -}}
+{{ toYaml .Values.deployment.management.limits }}
+{{- end -}}
 {{- else }}
-{{ toYaml .Values.deployment.workload }}
+{{ toYaml .Values.deployment.workload.requests }}
+{{- if eq (include "resource.vpa.enabled" .) "false" -}}
+{{ toYaml .Values.deployment.workloadg.limits }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/app-operator/templates/_resource.tpl
+++ b/helm/app-operator/templates/_resource.tpl
@@ -58,7 +58,7 @@ the per workload cluster instances.
 {{- else }}
 {{ toYaml .Values.deployment.workload.requests }}
 {{- if eq (include "resource.vpa.enabled" .) "false" -}}
-{{ toYaml .Values.deployment.workloadg.limits }}
+{{ toYaml .Values.deployment.workload.limits }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/app-operator/templates/_resource.tpl
+++ b/helm/app-operator/templates/_resource.tpl
@@ -38,9 +38,6 @@ CR version of 0.0.0.
 {{- if eq $.Chart.Name $.Release.Name }}0.0.0{{ else }}{{ .Chart.AppVersion }}{{ end }}
 {{- end -}}
 
-{{/*
-
-*/}}
 {{- define "resource.vpa.enabled" -}}
 {{- if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") (.Values.verticalPodAutoscaler.enabled) }}true{{ else }}false{{ end }}
 {{- end -}}
@@ -51,14 +48,18 @@ the per workload cluster instances.
 */}}
 {{- define "resource.deployment.resources" -}}
 {{- if eq (include "resource.app.unique" .) "true" -}}
-{{ toYaml .Values.deployment.management.requests }}
-{{- if eq (include "resource.vpa.enabled" .) "false" -}}
-{{ toYaml .Values.deployment.management.limits }}
+requests:
+{{ toYaml .Values.deployment.management.requests | indent 2 -}}
+{{ if eq (include "resource.vpa.enabled" .) "false" }}
+limits:
+{{ toYaml .Values.deployment.management.limits | indent 2 -}}
 {{- end -}}
 {{- else }}
-{{ toYaml .Values.deployment.workload.requests }}
-{{- if eq (include "resource.vpa.enabled" .) "false" -}}
-{{ toYaml .Values.deployment.workload.limits }}
+request:
+{{ toYaml .Values.deployment.workload.requests | indent 2 -}}
+{{ if eq (include "resource.vpa.enabled" .) "false" }}
+limits:
+{{ toYaml .Values.deployment.workload.limits | indent 2 -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -63,3 +63,4 @@ spec:
           timeoutSeconds: 1
         resources:
 {{ include "resource.deployment.resources" . | indent 10 }}
+q

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -62,4 +62,4 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
-{{ include "resource.deployment.resources" . | indent 10 }}
+{{- include "resource.deployment.resources" . | indent 10 }}

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -63,4 +63,3 @@ spec:
           timeoutSeconds: 1
         resources:
 {{ include "resource.deployment.resources" . | indent 10 }}
-q

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -62,4 +62,4 @@ spec:
           initialDelaySeconds: 15
           timeoutSeconds: 1
         resources:
-{{- include "resource.deployment.resources" . | indent 10 }}
+{{ include "resource.deployment.resources" . | indent 10 }}

--- a/helm/app-operator/templates/vpa.yaml
+++ b/helm/app-operator/templates/vpa.yaml
@@ -10,16 +10,7 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: {{ include "name" . }}
-      controlledResources:
-        - cpu
-        - memory
-      maxAllowed:
-        cpu: 1
-        memory: 1000Mi
-      minAllowed:
-        cpu: 250m
-        memory: 250Mi
-#      controlledValues: RequestsAndLimits
+      controlledValues: RequestsAndLimits
       mode: Auto
   targetRef:
     apiVersion: apps/v1

--- a/helm/app-operator/templates/vpa.yaml
+++ b/helm/app-operator/templates/vpa.yaml
@@ -1,4 +1,4 @@
-{{ if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") (.Values.verticalPodAutoscaler.enabled) }}
+{{ if eq (include "resource.vpa.enabled" .) "true" }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/helm/app-operator/templates/vpa.yaml
+++ b/helm/app-operator/templates/vpa.yaml
@@ -19,7 +19,6 @@ spec:
       minAllowed:
         cpu: 250m
         memory: 250Mi
-#      controlledValues: RequestsAndLimits
       mode: Auto
   targetRef:
     apiVersion: apps/v1

--- a/helm/app-operator/templates/vpa.yaml
+++ b/helm/app-operator/templates/vpa.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "resource.vpa.enabled" .) "true" -}}
+{{ if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") (.Values.verticalPodAutoscaler.enabled) }}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -15,7 +15,7 @@ spec:
         - memory
       maxAllowed:
         cpu: 1000m
-        memory: 1000qMi
+        memory: 1000Mi
       minAllowed:
         cpu: 250m
         memory: 250Mi

--- a/helm/app-operator/templates/vpa.yaml
+++ b/helm/app-operator/templates/vpa.yaml
@@ -1,4 +1,4 @@
-{{ if and (.Capabilities.APIVersions.Has "autoscaling.k8s.io/v1") (.Values.verticalPodAutoscaler.enabled) }}
+{{- if eq (include "resource.vpa.enabled" .) "true" -}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -14,8 +14,8 @@ spec:
         - cpu
         - memory
       maxAllowed:
-        cpu: 1
-        memory: 1000Mi
+        cpu: 1000m
+        memory: 1000qMi
       minAllowed:
         cpu: 250m
         memory: 250Mi

--- a/helm/app-operator/templates/vpa.yaml
+++ b/helm/app-operator/templates/vpa.yaml
@@ -10,7 +10,16 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: {{ include "name" . }}
-      controlledValues: RequestsAndLimits
+      controlledResources:
+        - cpu
+        - memory
+      maxAllowed:
+        cpu: 1
+        memory: 1000Mi
+      minAllowed:
+        cpu: 250m
+        memory: 250Mi
+#      controlledValues: RequestsAndLimits
       mode: Auto
   targetRef:
     apiVersion: apps/v1

--- a/helm/app-operator/values.yaml
+++ b/helm/app-operator/values.yaml
@@ -42,10 +42,16 @@ deployment:
     requests:
       cpu: 250m
       memory: 250Mi
+    limits:
+      cpu: 350m
+      memory: 500Mi
   workload:
     requests:
       cpu: 100m
       memory: 50Mi
+    limits:
+      cpu: 150m
+      memory: 100Mi
 
 verticalPodAutoscaler:
   enabled: true

--- a/helm/app-operator/values.yaml
+++ b/helm/app-operator/values.yaml
@@ -42,13 +42,9 @@ deployment:
     requests:
       cpu: 250m
       memory: 250Mi
-    limits:
-      memory: 280Mi
   workload:
     requests:
       cpu: 100m
-      memory: 50Mi
-    limits:
       memory: 50Mi
 
 verticalPodAutoscaler:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21980

Removing the `limits` from the `Deployment` lets the `VPA` figure out the proper resource limits (based on historic data it collects and analyses) that it sets when the pod starts. The controller keeps watching the pod and updates the limits / recreates the pod if needed within the max limits set in the `VPA`.

If the VPA is unavailable or not enabled we still set the the `limits` on the `Deployment`.

## References

- https://github.com/kubernetes/design-proposals-archive/blob/main/autoscaling/vertical-pod-autoscaler.md
- https://www.giantswarm.io/blog/vertical-autoscaling-in-kubernetes

## Checklist

- [x] Update changelog in CHANGELOG.md.
