### PR TITLE
Add support for barebone clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add `initialBootstrapMode` flag to allow deploying CNI as managed apps.
+
 ## [5.11.0] - 2022-05-23
 
 ### Changed

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -28,6 +28,14 @@ spec:
           - key: config.yaml
             path: config.yaml
       serviceAccountName: {{ include "resource.default.name"  . }}
+      {{- if .Values.initialBootstrapMode }}
+      hostNetwork: true
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      {{- end }}
       securityContext:
         runAsUser: {{ .Values.userID }}
         runAsGroup: {{ .Values.groupID }}
@@ -49,6 +57,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.initialBootstrapMode }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: 127.0.0.1
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
         - name: {{ include "name" . }}-configmap
           mountPath: /var/run/{{ include "name" . }}/configmap/
         {{- if not .Values.initialBootstrapMode }}
+        # When initialBootstrapMode is true, this pod runs in `hostNetwork` mode.
+        # This means kubernetes automatically adds an hostPort field in the `ports` section below.
+        # When initialBootstrapMode is set back to false, the hostPort field is not removed and that makes the replicaset to fail.
         ports:
         - name: http
           containerPort: {{ .Values.port }}

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
         # When initialBootstrapMode is true, this pod runs in `hostNetwork` mode.
         # This means kubernetes automatically adds an hostPort field in the `ports` section below.
         # When initialBootstrapMode is set back to false, the hostPort field is not removed and that makes the replicaset to fail.
+        # By removing the whole `ports` section when `initialBootstrapMode` is true we allow switching between the two modes
+        # without any manual intervention required.
         ports:
         - name: http
           containerPort: {{ .Values.port }}

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -45,9 +45,11 @@ spec:
         volumeMounts:
         - name: {{ include "name" . }}-configmap
           mountPath: /var/run/{{ include "name" . }}/configmap/
+        {{- if not .Values.initialBootstrapMode }}
         ports:
         - name: http
           containerPort: {{ .Values.port }}
+        {{- end }}
         args:
         - daemon
         - --config.dirs=/var/run/{{ include "name" . }}/configmap/

--- a/helm/app-operator/templates/psp.yaml
+++ b/helm/app-operator/templates/psp.yaml
@@ -26,13 +26,6 @@ spec:
     - 'configMap'
     - 'projected'
   allowPrivilegeEscalation: false
-  {{- if .Values.initialBootstrapMode }}
-  hostNetwork: true
-  hostPorts:
-  - min: {{ .Values.port }}
-    max: {{ .Values.port }}
-  {{- else }}
-  hostNetwork: false
-  {{- end }}
+  hostNetwork: {{ .Values.initialBootstrapMode }}
   hostIPC: false
   hostPID: false

--- a/helm/app-operator/templates/psp.yaml
+++ b/helm/app-operator/templates/psp.yaml
@@ -24,7 +24,15 @@ spec:
     rule: RunAsAny
   volumes:
     - 'configMap'
+    - 'projected'
   allowPrivilegeEscalation: false
+  {{- if .Values.initialBootstrapMode }}
+  hostNetwork: true
+  hostPorts:
+  - min: {{ .Values.port }}
+    max: {{ .Values.port }}
+  {{- else }}
   hostNetwork: false
+  {{- end }}
   hostIPC: false
   hostPID: false

--- a/helm/app-operator/values.yaml
+++ b/helm/app-operator/values.yaml
@@ -55,3 +55,14 @@ deployment:
 
 verticalPodAutoscaler:
   enabled: true
+
+# When this flag is true, app operator runs in special mode in order to be able to run in partially deployed clusters.
+# Main differences are:
+# - runs on master nodes
+# - runs on hostNetwork
+# - tolerates all taints
+# - uses API hostname to reach the API to support kube-proxy being missing
+# This mode is meant to be used during bootstrap of management clusters to be able to deploy basic system services
+# (such as the CNI or the out-of-tree cloud controller managers) as a managed app.
+# After the cluster is fully deployed, this flag should be switched to false.
+initialBootstrapMode: false


### PR DESCRIPTION
`app-operator` is one of the first applications to run in a brand new management cluster.

Currently it requires a fully bootstrapped cluster (with CNI, kube-proxy and any out-of-tree cloud controller manager running) in order to even start.
This creates a chicken-egg problem that forces us to have ugly bash scripts that deploy the aforementioned core components as kubernetes manifests through bash scripts during nodes startup.

We would like to be able to deploy core components of a cluster as managed apps, but this requires relaxing `app-operator` needs.

This PR adds a new values.yaml parameter named `initialBootstrap` defaulting to false to make this release 100% retrocompatible. If the flag is set to true, app operator supports any taint, runs on the master node and on the host network, and with a few tricks here and there to make it run fine on clusters with no CNI, no kube-proxy and no cloud controller manager running.

As soon as flux starts reconciling the `app-operator` `App`, the `initialBootstrap` flag gets automatically reverted and app operator begins running normally.

I understand this is a workaround, but I believe it is better to have this workaround here if it allows us to get rid of a big chunk of complicated bash scripts and `kubectl apply` in the node's bootstrap.

WDYT?

## Checklist

- [x] Update changelog in CHANGELOG.md.
