### PR TITLE
Allow to set api server pod port when enabling initialBootstrapMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Allow to set api server pod port when enabling `initialBootstrapMode`.
+
 ## [6.0.1] - 2022-06-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use downward API to set deployment env var `KUBERNETES_SERVICE_HOST` to `status.hostIP`.
+
 ### Added
 
 - Allow to set api server pod port when enabling `initialBootstrapMode`.

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           - key: config.yaml
             path: config.yaml
       serviceAccountName: {{ include "resource.default.name"  . }}
-      {{- if .Values.initialBootstrapMode }}
+      {{- if .Values.initialBootstrapMode.enabled }}
       hostNetwork: true
       tolerations:
       - effect: NoSchedule
@@ -45,11 +45,11 @@ spec:
         volumeMounts:
         - name: {{ include "name" . }}-configmap
           mountPath: /var/run/{{ include "name" . }}/configmap/
-        {{- if not .Values.initialBootstrapMode }}
-        # When initialBootstrapMode is true, this pod runs in `hostNetwork` mode.
+        {{- if not .Values.initialBootstrapMode.enabled }}
+        # When `initialBootstrapMode.enabled` is true, this pod runs in `hostNetwork` mode.
         # This means kubernetes automatically adds an hostPort field in the `ports` section below.
-        # When initialBootstrapMode is set back to false, the hostPort field is not removed and that makes the replicaset to fail.
-        # By removing the whole `ports` section when `initialBootstrapMode` is true we allow switching between the two modes
+        # When `initialBootstrapMode.enabled` is set back to false, the hostPort field is not removed and that makes the replicaset to fail.
+        # By removing the whole `ports` section when `initialBootstrapMode.enabled` is true we allow switching between the two modes
         # without any manual intervention required.
         ports:
         - name: http
@@ -64,9 +64,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        {{- if .Values.initialBootstrapMode }}
+        {{- if .Values.initialBootstrapMode.enabled }}
         - name: KUBERNETES_SERVICE_HOST
           value: 127.0.0.1
+        - name: KUBERNETES_SERVICE_PORT
+          value: {{ .Values.initialBootstrapMode.apiServerPodPort | quote }}
         {{- end }}
         livenessProbe:
           httpGet:

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -66,7 +66,9 @@ spec:
               fieldPath: metadata.namespace
         {{- if .Values.initialBootstrapMode.enabled }}
         - name: KUBERNETES_SERVICE_HOST
-          value: 127.0.0.1
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: KUBERNETES_SERVICE_PORT
           value: {{ .Values.initialBootstrapMode.apiServerPodPort | quote }}
         {{- end }}

--- a/helm/app-operator/templates/pod-monitor.yaml
+++ b/helm/app-operator/templates/pod-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.initialBootstrapMode }}
+{{- if not .Values.initialBootstrapMode.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/helm/app-operator/templates/psp.yaml
+++ b/helm/app-operator/templates/psp.yaml
@@ -26,6 +26,6 @@ spec:
     - 'configMap'
     - 'projected'
   allowPrivilegeEscalation: false
-  hostNetwork: {{ .Values.initialBootstrapMode }}
+  hostNetwork: {{ .Values.initialBootstrapMode.enabled }}
   hostIPC: false
   hostPID: false

--- a/helm/app-operator/templates/psp.yaml
+++ b/helm/app-operator/templates/psp.yaml
@@ -25,6 +25,7 @@ spec:
   volumes:
     - 'configMap'
     - 'projected'
+    - 'secret'
   allowPrivilegeEscalation: false
   hostNetwork: {{ .Values.initialBootstrapMode.enabled }}
   hostIPC: false

--- a/helm/app-operator/values.yaml
+++ b/helm/app-operator/values.yaml
@@ -65,4 +65,6 @@ verticalPodAutoscaler:
 # This mode is meant to be used during bootstrap of management clusters to be able to deploy basic system services
 # (such as the CNI or the out-of-tree cloud controller managers) as a managed app.
 # After the cluster is fully deployed, this flag should be switched to false.
-initialBootstrapMode: false
+initialBootstrapMode:
+  apiServerPodPort: 443
+  enabled: false


### PR DESCRIPTION
Basically, the `initialBootstrapMode` mode overrides the `KUBERNETES_SERVICE_HOST` environment variable of the app-operator pod, setting it to 127.0.0.1, instead of the `kubernetes` default `Service` IP. But the `Service` uses the port `443`, and this is a problem, because when `app-operator` tries to contact the k8s api using `client-go`, it will try `127.0.0.1:443`, while the apiserver pod on CAPI uses the port `6443`.

On this PR we also overwrite `KUBERNETES_SERVICE_PORT` so that we can set `6443` on CAPI clusters.

## Checklist

- [X] Update changelog in CHANGELOG.md.
