### PR TITLE
Make `app-operator` PSS restricted compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Use downward API to set deployment env var `KUBERNETES_SERVICE_HOST` to `status.hostIP`.
+- Tighten pod and container security contexts for PSS restricted policies.
 
 ### Added
 

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.userID }}
         runAsGroup: {{ .Values.groupID }}
+        {{- with .Values.podSecurityContext }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
       containers:
       - name: {{ include "name" . }}
         image: "{{ .Values.registry.domain }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -86,3 +89,9 @@ spec:
           timeoutSeconds: 1
         resources:
 {{ include "resource.deployment.resources" . | indent 10 }}
+        securityContext:
+          runAsUser: {{ .Values.userID }}
+          runAsGroup: {{ .Values.groupID }}
+          {{- with .Values.securityContext }}
+            {{- . | toYaml | nindent 10 }}
+          {{- end }}

--- a/helm/app-operator/templates/psp.yaml
+++ b/helm/app-operator/templates/psp.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "resource.psp.name" . }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 spec:
   privileged: false
   fsGroup:

--- a/helm/app-operator/values.yaml
+++ b/helm/app-operator/values.yaml
@@ -85,4 +85,3 @@ securityContext:
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
-

--- a/helm/app-operator/values.yaml
+++ b/helm/app-operator/values.yaml
@@ -68,3 +68,21 @@ verticalPodAutoscaler:
 initialBootstrapMode:
   apiServerPodPort: 443
   enabled: false
+
+# Pod securityContext
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container securityContext
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  privileged: false
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+


### PR DESCRIPTION
Sets the default/runtime seccomp profile, and more explicitly restrictive securityContexts for the pod and container

## Checklist

- [x] Update changelog in CHANGELOG.md.
