### PR TITLE
Add support for k8s 1.24 control plane label

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -11,7 +11,7 @@ CVE-2022-24687 until=2022-12-31
 CVE-2021-23772 until=2022-08-30
 
 # pkg:golang/github.com/mholt/archiver/v3@v3.5.0
-sonatype-2022-0204 until=2022-06-30
+sonatype-2022-0204 until=2022-08-30
 
 # pkg:golang/github.com/urfave/negroni@v1.0.0
 # This library seems to be abandoned
@@ -19,16 +19,16 @@ sonatype-2021-1485 until=2022-12-31
 
 # pkg:golang/helm.sh/helm/v3@v3.9.0
 # This is the latest release at the moment
-CVE-2018-1714 until=2022-06-30
+CVE-2018-1714 until=2022-08-30
 
 # pkg:github.com/containerd/containerd@v1.6.4
 # unused dependency of spf13 libraries
-CVE-2022-31030 until=2022-07-01
+CVE-2022-31030 until=2022-08-30
 
 # pkg:golang/github.com/kataras/iris/v12@v12.1.8
 # imported from:
 #  - github.com/getsentry/sentry-go@v0.13.0
-CVE-2021-23772 until=2022-08-01
+CVE-2021-23772 until=2022-08-30
 
 # pkg:golang/github.com/nats-io/jwt@v1.2.2
 # imported from:
@@ -39,7 +39,7 @@ CVE-2021-3127 until=2022-08-30
 CVE-2020-26892 until=2022-08-30
 
 # pkg:golang/helm.sh/helm/v3@v3.9.0
-CVE-2018-1714 until=2022-08-01
+CVE-2018-1714 until=2022-08-30
 
 # pkg:golang/github.com/mholt/archiver/v3@v3.5.0
 # imported from:

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -11,7 +11,7 @@ CVE-2022-24687 until=2022-12-31
 CVE-2021-23772 until=2022-08-30
 
 # pkg:golang/github.com/mholt/archiver/v3@v3.5.0
-sonatype-2022-0204 until=2022-08-30
+sonatype-2022-0204 until=2022-06-30
 
 # pkg:golang/github.com/urfave/negroni@v1.0.0
 # This library seems to be abandoned
@@ -19,16 +19,16 @@ sonatype-2021-1485 until=2022-12-31
 
 # pkg:golang/helm.sh/helm/v3@v3.9.0
 # This is the latest release at the moment
-CVE-2018-1714 until=2022-08-30
+CVE-2018-1714 until=2022-06-30
 
 # pkg:github.com/containerd/containerd@v1.6.4
 # unused dependency of spf13 libraries
-CVE-2022-31030 until=2022-08-30
+CVE-2022-31030 until=2022-07-01
 
 # pkg:golang/github.com/kataras/iris/v12@v12.1.8
 # imported from:
 #  - github.com/getsentry/sentry-go@v0.13.0
-CVE-2021-23772 until=2022-08-30
+CVE-2021-23772 until=2022-08-01
 
 # pkg:golang/github.com/nats-io/jwt@v1.2.2
 # imported from:
@@ -39,7 +39,7 @@ CVE-2021-3127 until=2022-08-30
 CVE-2020-26892 until=2022-08-30
 
 # pkg:golang/helm.sh/helm/v3@v3.9.0
-CVE-2018-1714 until=2022-08-30
+CVE-2018-1714 until=2022-08-01
 
 # pkg:golang/github.com/mholt/archiver/v3@v3.5.0
 # imported from:

--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -45,3 +45,5 @@ CVE-2018-1714 until=2022-08-30
 # imported from:
 #  - github.com/giantswarm/helmclient/v4
 sonatype-2022-0204 until=2022-08-30
+
+sonatype-2021-0276 until=2022-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add support for new control-plane label in k8s 1.24.
+
 ## [6.3.0] - 2022-07-11
 
 ### Added

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -33,8 +33,13 @@ spec:
       tolerations:
       - effect: NoSchedule
         operator: Exists
+      {{- if ge (int .Capabilities.KubeVersion.Minor) 24 }}
       nodeSelector:
-        node-role.kubernetes.io/master: ""
+        node-role.kubernetes.io/control-plane: ""
+      {{- else }}
+      nodeSelector:
+        node-role.kubernetes.io/master: ""      
+      {{- end }}
       {{- end }}
       securityContext:
         runAsUser: {{ .Values.userID }}

--- a/helm/app-operator/templates/deployment.yaml
+++ b/helm/app-operator/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         node-role.kubernetes.io/control-plane: ""
       {{- else }}
       nodeSelector:
-        node-role.kubernetes.io/master: ""      
+        node-role.kubernetes.io/master: ""
       {{- end }}
       {{- end }}
       securityContext:


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.

k8s 1.24 no longer uses master and uses control-plane

ref: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes