### PR TITLE
Use port field instead of deprecated targetPort field for PodMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Use `port` instead of deprecated `targetPort` field for `PodMonitor`
+
 ## [6.4.2] - 2022-11-21
 
 ### Changed

--- a/helm/app-operator/templates/pod-monitor.yaml
+++ b/helm/app-operator/templates/pod-monitor.yaml
@@ -14,5 +14,5 @@ spec:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
   podMetricsEndpoints:
-    - targetPort: {{ .Values.port }}
+    - port: {{ .Values.port }}
 {{- end }}

--- a/helm/app-operator/templates/pod-monitor.yaml
+++ b/helm/app-operator/templates/pod-monitor.yaml
@@ -14,5 +14,5 @@ spec:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
   podMetricsEndpoints:
-    - port: {{ .Values.port }}
+    - port: "{{ .Values.port }}"
 {{- end }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/24602

## Checklist

- [x] Update changelog in CHANGELOG.md.
