### PR TITLE
Build URLs for OCI Repositories in non-internal Catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix building URLs for OCI Repositories assigned to non-internal `Catalogs`.
+
 ## [6.4.4] - 2022-11-29
 
 ### Fixed

--- a/service/controller/app/resource/chart/desired_test.go
+++ b/service/controller/app/resource/chart/desired_test.go
@@ -801,14 +801,10 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 			Title:       "Giant Swarm",
 			Description: "Catalog of Apps by Giant Swarm",
 			Storage: v1alpha1.CatalogSpecStorage{
-				Type: "oci",
-				URL:  "oci://giantswarmpublic.azurecr.io/app-catalog/",
+				Type: "helm",
+				URL:  "https://giantswarm.github.io/app-catalog-mirror/",
 			},
 			Repositories: []v1alpha1.CatalogSpecRepository{
-				{
-					Type: "oci",
-					URL:  "oci://giantswarmpublic.azurecr.io/app-catalog/",
-				},
 				{
 					Type: "helm",
 					URL:  "https://giantswarm.github.io/app-catalog-mirror/",


### PR DESCRIPTION
Coming from [#inc-2022-12-02-hyperion-org-sw-dbamimir-zuug0-grafana](https://gigantic.slack.com/archives/C04DE13367P) incident.

- build URLs for non-internal OCI repositories
- update CHANGELOG

## Checklist

- [x] Update changelog in CHANGELOG.md.
