### PR TITLE
Dependencies

### DIFF
--- a/flag/service/app/app.go
+++ b/flag/service/app/app.go
@@ -1,7 +1,8 @@
 package app
 
 type App struct {
-	Unique            string
-	WatchNamespace    string
-	WorkloadClusterID string
+	Unique                       string
+	WatchNamespace               string
+	WorkloadClusterID            string
+	DependencyWaitTimeoutMinutes string
 }

--- a/helm/app-operator/templates/configmap.yaml
+++ b/helm/app-operator/templates/configmap.yaml
@@ -18,6 +18,7 @@ data:
         unique: {{ include "resource.app.unique" . }}
         watchNamespace: '{{ .Values.app.watchNamespace }}'
         workloadClusterID: '{{ .Values.app.workloadClusterID }}'
+        dependencyWaitTimeoutMinutes: {{ .Values.app.dependencyWaitTimeoutMinutes }}
       helm:
         http:
           clientTimeout: '{{ .Values.helm.http.clientTimeout }}'

--- a/helm/app-operator/values.yaml
+++ b/helm/app-operator/values.yaml
@@ -10,6 +10,7 @@ protocol: "TCP"
 app:
   watchNamespace: ""
   workloadClusterID: ""
+  dependencyWaitTimeoutMinutes: 30
 
 helm:
   http:

--- a/integration/test/catalog/appcatalogentry/app_catalog_entry_test.go
+++ b/integration/test/catalog/appcatalogentry/app_catalog_entry_test.go
@@ -138,7 +138,7 @@ func TestAppCatalogEntry(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 			},
 			Chart: v1alpha1.AppCatalogEntrySpecChart{
-				APIVersion:  "v1",
+				APIVersion:  "v2",
 				Description: latestEntry.Description,
 				Home:        latestEntry.Home,
 				Icon:        latestEntry.Icon,

--- a/main.go
+++ b/main.go
@@ -149,6 +149,7 @@ func mainWithError() (err error) {
 	daemonCommand.PersistentFlags().Bool(f.Service.App.Unique, false, "Whether the operator is deployed as a unique app.")
 	daemonCommand.PersistentFlags().String(f.Service.App.WatchNamespace, "", "Namespace to watch for app CRs.")
 	daemonCommand.PersistentFlags().String(f.Service.App.WorkloadClusterID, "", "Workload cluster ID for app CR label selector.")
+	daemonCommand.PersistentFlags().Int(f.Service.App.DependencyWaitTimeoutMinutes, 30, "Timeout in seconds after which to ignore dependencies and make app installation to move on.")
 	daemonCommand.PersistentFlags().Int(f.Service.AppCatalog.MaxEntriesPerApp, 5, "The maximum number of appCatalogEntries per app.")
 	daemonCommand.PersistentFlags().String(f.Service.Chart.Namespace, "giantswarm", "The namespace where chart CRs are located.")
 	daemonCommand.PersistentFlags().String(f.Service.Helm.HTTP.ClientTimeout, "5s", "HTTP timeout for pulling chart tarballs.")

--- a/service/controller/app/app.go
+++ b/service/controller/app/app.go
@@ -31,15 +31,16 @@ type Config struct {
 	IndexCache  indexcache.Interface
 	Logger      micrologger.Logger
 
-	ChartNamespace    string
-	HTTPClientTimeout time.Duration
-	ImageRegistry     string
-	PodNamespace      string
-	Provider          string
-	ResyncPeriod      time.Duration
-	UniqueApp         bool
-	WatchNamespace    string
-	WorkloadClusterID string
+	ChartNamespace               string
+	HTTPClientTimeout            time.Duration
+	ImageRegistry                string
+	PodNamespace                 string
+	Provider                     string
+	ResyncPeriod                 time.Duration
+	UniqueApp                    bool
+	WatchNamespace               string
+	WorkloadClusterID            string
+	DependencyWaitTimeoutMinutes int
 }
 
 type App struct {
@@ -112,13 +113,14 @@ func NewApp(config Config) (*App, error) {
 			K8sClient:   config.K8sClient,
 			Logger:      config.Logger,
 
-			ChartNamespace:    config.ChartNamespace,
-			HTTPClientTimeout: config.HTTPClientTimeout,
-			ImageRegistry:     config.ImageRegistry,
-			ProjectName:       project.Name(),
-			Provider:          config.Provider,
-			UniqueApp:         config.UniqueApp,
-			WorkloadClusterID: config.WorkloadClusterID,
+			ChartNamespace:               config.ChartNamespace,
+			HTTPClientTimeout:            config.HTTPClientTimeout,
+			ImageRegistry:                config.ImageRegistry,
+			ProjectName:                  project.Name(),
+			Provider:                     config.Provider,
+			UniqueApp:                    config.UniqueApp,
+			WorkloadClusterID:            config.WorkloadClusterID,
+			DependencyWaitTimeoutMinutes: config.DependencyWaitTimeoutMinutes,
 		}
 
 		resources, err = newAppResources(c)

--- a/service/controller/app/app.go
+++ b/service/controller/app/app.go
@@ -81,6 +81,9 @@ func NewApp(config Config) (*App, error) {
 	if config.ResyncPeriod == 0 {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ResyncPeriod must not be empty", config)
 	}
+	if config.DependencyWaitTimeoutMinutes <= 0 {
+		return nil, microerror.Maskf(invalidConfigError, "%T.DependencyWaitTimeoutMinutes must be greater than 0", config)
+	}
 
 	// For non-unique instances if either watch namespace or cluster ID are
 	// provided both must be set.

--- a/service/controller/app/resource/chart/desired.go
+++ b/service/controller/app/resource/chart/desired.go
@@ -96,7 +96,6 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 	if len(depsNotInstalled) > 0 {
-		// TODO Check if timeout expired.
 		annotations[annotationChartOperatorPause] = "true"
 		annotations[annotationChartOperatorPauseReason] = fmt.Sprintf("Waiting for dependencies to be installed: %s", strings.Join(depsNotInstalled, ", "))
 		annotations[annotationChartOperatorPauseStarted] = time.Now().Format(time.RFC3339)

--- a/service/controller/app/resource/chart/desired.go
+++ b/service/controller/app/resource/chart/desired.go
@@ -97,8 +97,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		annotations[annotationChartOperatorPause] = "true"
 		annotations[annotationChartOperatorPauseReason] = fmt.Sprintf("Waiting for dependencies to be installed: %s", strings.Join(depsNotInstalled, ", "))
 	} else {
-		annotations[annotationChartOperatorPause] = "false"
-		annotations[annotationChartOperatorPauseReason] = ""
+		annotations[fmt.Sprintf("%s-", annotationChartOperatorPause)] = ""
+		annotations[fmt.Sprintf("%s-", annotationChartOperatorPauseReason)] = ""
 	}
 
 	chartCR := &v1alpha1.Chart{

--- a/service/controller/app/resource/chart/desired.go
+++ b/service/controller/app/resource/chart/desired.go
@@ -98,8 +98,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		annotations[annotationChartOperatorPause] = "true"
 		annotations[annotationChartOperatorPauseReason] = fmt.Sprintf("Waiting for dependencies to be installed: %s", strings.Join(depsNotInstalled, ", "))
 	} else {
-		annotations[annotationChartOperatorPause] = "DELETE"
-		annotations[annotationChartOperatorPauseReason] = "DELETE"
+		annotations[annotationChartOperatorPause] = "DELETE"       //nolint:goconst
+		annotations[annotationChartOperatorPauseReason] = "DELETE" //nolint:goconst
 	}
 
 	chartCR := &v1alpha1.Chart{

--- a/service/controller/app/resource/chart/desired.go
+++ b/service/controller/app/resource/chart/desired.go
@@ -96,6 +96,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	if len(depsNotInstalled) > 0 {
 		annotations[annotationChartOperatorPause] = "true"
 		annotations[annotationChartOperatorPauseReason] = fmt.Sprintf("Waiting for dependencies to be installed: %s", strings.Join(depsNotInstalled, ", "))
+	} else {
+		annotations[annotationChartOperatorPause] = "false"
+		annotations[annotationChartOperatorPauseReason] = ""
 	}
 
 	chartCR := &v1alpha1.Chart{

--- a/service/controller/app/resource/chart/desired.go
+++ b/service/controller/app/resource/chart/desired.go
@@ -131,7 +131,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 
 func (r *Resource) checkDependencies(ctx context.Context, cc *controllercontext.Context, app v1alpha1.App) ([]string, error) {
 	appList := v1alpha1.AppList{}
-	err := cc.Clients.K8s.CtrlClient().List(ctx, &appList, client.InNamespace(app.Namespace))
+	err := r.ctrlClient.List(ctx, &appList, client.InNamespace(app.Namespace))
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/app/resource/chart/desired.go
+++ b/service/controller/app/resource/chart/desired.go
@@ -98,8 +98,8 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		annotations[annotationChartOperatorPause] = "true"
 		annotations[annotationChartOperatorPauseReason] = fmt.Sprintf("Waiting for dependencies to be installed: %s", strings.Join(depsNotInstalled, ", "))
 	} else {
-		annotations[fmt.Sprintf("%s-", annotationChartOperatorPause)] = ""
-		annotations[fmt.Sprintf("%s-", annotationChartOperatorPauseReason)] = ""
+		annotations[annotationChartOperatorPause] = "DELETE"
+		annotations[annotationChartOperatorPauseReason] = "DELETE"
 	}
 
 	chartCR := &v1alpha1.Chart{

--- a/service/controller/app/resource/chart/desired.go
+++ b/service/controller/app/resource/chart/desired.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/app/v6/pkg/key"
@@ -95,9 +96,10 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 	if len(depsNotInstalled) > 0 {
+		// TODO Check if timeout expired.
 		annotations[annotationChartOperatorPause] = "true"
 		annotations[annotationChartOperatorPauseReason] = fmt.Sprintf("Waiting for dependencies to be installed: %s", strings.Join(depsNotInstalled, ", "))
-		//annotations[annotationChartOperatorPauseStarted] = ""
+		annotations[annotationChartOperatorPauseStarted] = time.Now().Format(time.RFC3339)
 	}
 
 	chartCR := &v1alpha1.Chart{

--- a/service/controller/app/resource/chart/desired.go
+++ b/service/controller/app/resource/chart/desired.go
@@ -29,9 +29,9 @@ const (
 	chartPullFailedStatus = "chart-pull-failed"
 
 	annotationChartOperatorPause        = "chart-operator.giantswarm.io/paused"
-	annotationChartOperatorPauseReason  = "chart-operator.giantswarm.io/pause-reason"
-	annotationChartOperatorPauseStarted = "chart-operator.giantswarm.io/pause-ts"
-	annotationChartOperatorDependsOn    = "chart-operator.giantswarm.io/depends-on"
+	annotationChartOperatorPauseReason  = "app-operator.giantswarm.io/pause-reason"
+	annotationChartOperatorPauseStarted = "app-operator.giantswarm.io/pause-ts"
+	annotationChartOperatorDependsOn    = "app-operator.giantswarm.io/depends-on"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
@@ -97,9 +97,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	if len(depsNotInstalled) > 0 {
 		annotations[annotationChartOperatorPause] = "true"
 		annotations[annotationChartOperatorPauseReason] = fmt.Sprintf("Waiting for dependencies to be installed: %s", strings.Join(depsNotInstalled, ", "))
-	} else {
-		annotations[annotationChartOperatorPause] = "DELETE"       //nolint:goconst
-		annotations[annotationChartOperatorPauseReason] = "DELETE" //nolint:goconst
+		//annotations[annotationChartOperatorPauseStarted] = ""
 	}
 
 	chartCR := &v1alpha1.Chart{

--- a/service/controller/app/resource/chart/desired_test.go
+++ b/service/controller/app/resource/chart/desired_test.go
@@ -1588,3 +1588,64 @@ func newIndexWithApp(app, version, url string) *indexcache.Index {
 
 	return index
 }
+
+func Test_getDependenciesFromCR(t *testing.T) {
+	tests := []struct {
+		name            string
+		annotationValue string
+		want            []string
+		wantErr         bool
+	}{
+		{
+			name:            "Annotation exists with one app",
+			annotationValue: "coredns",
+			want:            []string{"coredns"},
+			wantErr:         false,
+		},
+		{
+			name:            "Annotation exists with two apps",
+			annotationValue: "coredns,prometheus",
+			want:            []string{"coredns", "prometheus"},
+			wantErr:         false,
+		},
+		{
+			name:            "Annotation does not exist",
+			annotationValue: "",
+			want:            []string{},
+			wantErr:         false,
+		},
+		{
+			name:            "Annotation with typo",
+			annotationValue: "coredns,,prometheus",
+			want:            []string{"coredns", "prometheus"},
+			wantErr:         false,
+		},
+		{
+			name:            "Annotation with just a comma",
+			annotationValue: ",",
+			want:            []string{},
+			wantErr:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotations := map[string]string{}
+			if tt.annotationValue != "" {
+				annotations["chart-operator.giantswarm.io/depends-on"] = tt.annotationValue
+			}
+			app := v1alpha1.App{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: annotations,
+				},
+			}
+			got, err := getDependenciesFromCR(app)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getDependenciesFromCR() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getDependenciesFromCR() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/service/controller/app/resource/chart/desired_test.go
+++ b/service/controller/app/resource/chart/desired_test.go
@@ -682,7 +682,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 			var ctx context.Context
 			{
 				s := runtime.NewScheme()
-				s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.Chart{}, &v1alpha1.ChartList{})
+				s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.Chart{}, &v1alpha1.ChartList{}, &v1alpha1.AppList{})
 				config := k8sclienttest.ClientsConfig{
 					CtrlClient: fake.NewFakeClientWithScheme(s), //nolint:staticcheck
 					K8sClient:  clientgofake.NewSimpleClientset(objs...),
@@ -1161,7 +1161,7 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 			var ctx context.Context
 			{
 				s := runtime.NewScheme()
-				s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.Chart{}, &v1alpha1.ChartList{})
+				s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.Chart{}, &v1alpha1.ChartList{}, &v1alpha1.AppList{})
 				config := k8sclienttest.ClientsConfig{
 					CtrlClient: fake.NewFakeClientWithScheme(s, objs...), //nolint:staticcheck
 					K8sClient:  clientgofake.NewSimpleClientset(),

--- a/service/controller/app/resource/chart/desired_test.go
+++ b/service/controller/app/resource/chart/desired_test.go
@@ -114,8 +114,6 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
-						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -261,8 +259,6 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 						"chart-operator.giantswarm.io/app-name":           "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace":      "default",
 						"chart-operator.giantswarm.io/force-helm-upgrade": "true",
-						"chart-operator.giantswarm.io/pause-reason":       "DELETE",
-						"chart-operator.giantswarm.io/paused":             "DELETE",
 					},
 					Name:      "my-cool-prometheus",
 					Namespace: "giantswarm",
@@ -358,8 +354,6 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
-						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -447,8 +441,6 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
-						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -529,8 +521,6 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "hello-world",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
-						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"chart-operator.giantswarm.io/version": "1.0.0",
@@ -639,8 +629,6 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
-						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -865,8 +853,6 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
-						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -936,8 +922,6 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
-						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -1017,8 +1001,6 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
-						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -1098,8 +1080,6 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
-						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -1141,8 +1121,6 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
-						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -1631,7 +1609,7 @@ func Test_getDependenciesFromCR(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			annotations := map[string]string{}
 			if tt.annotationValue != "" {
-				annotations["chart-operator.giantswarm.io/depends-on"] = tt.annotationValue
+				annotations["app-operator.giantswarm.io/depends-on"] = tt.annotationValue
 			}
 			app := v1alpha1.App{
 				ObjectMeta: metav1.ObjectMeta{

--- a/service/controller/app/resource/chart/desired_test.go
+++ b/service/controller/app/resource/chart/desired_test.go
@@ -676,7 +676,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				Logger:     microloggertest.New(),
 				CtrlClient: fake.NewFakeClientWithScheme(s), //nolint:staticcheck
 
-				ChartNamespace: "giantswarm",
+				ChartNamespace:               "giantswarm",
+				DependencyWaitTimeoutMinutes: 30,
 			}
 			r, err := New(c)
 			if err != nil {
@@ -1159,7 +1160,8 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 				Logger:     microloggertest.New(),
 				CtrlClient: fake.NewFakeClientWithScheme(s), //nolint:staticcheck
 
-				ChartNamespace: "giantswarm",
+				ChartNamespace:               "giantswarm",
+				DependencyWaitTimeoutMinutes: 30,
 			}
 			r, err := New(c)
 			if err != nil {

--- a/service/controller/app/resource/chart/desired_test.go
+++ b/service/controller/app/resource/chart/desired_test.go
@@ -666,11 +666,15 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 				objs = append(objs, tc.secret)
 			}
 
+			s := runtime.NewScheme()
+			s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.AppList{})
+
 			c := Config{
 				IndexCache: indexcachetest.New(indexcachetest.Config{
 					GetIndexResponse: tc.index,
 				}),
-				Logger: microloggertest.New(),
+				Logger:     microloggertest.New(),
+				CtrlClient: fake.NewFakeClientWithScheme(s), //nolint:staticcheck
 
 				ChartNamespace: "giantswarm",
 			}
@@ -682,7 +686,7 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 			var ctx context.Context
 			{
 				s := runtime.NewScheme()
-				s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.Chart{}, &v1alpha1.ChartList{}, &v1alpha1.AppList{})
+				s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.Chart{}, &v1alpha1.ChartList{})
 				config := k8sclienttest.ClientsConfig{
 					CtrlClient: fake.NewFakeClientWithScheme(s), //nolint:staticcheck
 					K8sClient:  clientgofake.NewSimpleClientset(objs...),
@@ -1147,9 +1151,13 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 				objs = append(objs, tc.existingChart)
 			}
 
+			s := runtime.NewScheme()
+			s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.AppList{})
+
 			c := Config{
 				IndexCache: indexcachetest.NewMap(tc.indices),
 				Logger:     microloggertest.New(),
+				CtrlClient: fake.NewFakeClientWithScheme(s), //nolint:staticcheck
 
 				ChartNamespace: "giantswarm",
 			}
@@ -1161,7 +1169,7 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 			var ctx context.Context
 			{
 				s := runtime.NewScheme()
-				s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.Chart{}, &v1alpha1.ChartList{}, &v1alpha1.AppList{})
+				s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.Chart{}, &v1alpha1.ChartList{})
 				config := k8sclienttest.ClientsConfig{
 					CtrlClient: fake.NewFakeClientWithScheme(s, objs...), //nolint:staticcheck
 					K8sClient:  clientgofake.NewSimpleClientset(),

--- a/service/controller/app/resource/chart/desired_test.go
+++ b/service/controller/app/resource/chart/desired_test.go
@@ -114,6 +114,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
+						"chart-operator.giantswarm.io/pause-reason-": "",
+						"chart-operator.giantswarm.io/paused-":       "",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -259,6 +261,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 						"chart-operator.giantswarm.io/app-name":           "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace":      "default",
 						"chart-operator.giantswarm.io/force-helm-upgrade": "true",
+						"chart-operator.giantswarm.io/pause-reason-":      "",
+						"chart-operator.giantswarm.io/paused-":            "",
 					},
 					Name:      "my-cool-prometheus",
 					Namespace: "giantswarm",
@@ -354,6 +358,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
+						"chart-operator.giantswarm.io/pause-reason-": "",
+						"chart-operator.giantswarm.io/paused-":       "",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -441,6 +447,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
+						"chart-operator.giantswarm.io/pause-reason-": "",
+						"chart-operator.giantswarm.io/paused-":       "",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -521,6 +529,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "hello-world",
 						"chart-operator.giantswarm.io/app-namespace": "default",
+						"chart-operator.giantswarm.io/pause-reason-": "",
+						"chart-operator.giantswarm.io/paused-":       "",
 					},
 					Labels: map[string]string{
 						"chart-operator.giantswarm.io/version": "1.0.0",
@@ -629,6 +639,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
+						"chart-operator.giantswarm.io/pause-reason-": "",
+						"chart-operator.giantswarm.io/paused-":       "",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -853,6 +865,8 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
+						"chart-operator.giantswarm.io/pause-reason-": "",
+						"chart-operator.giantswarm.io/paused-":       "",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -922,6 +936,8 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
+						"chart-operator.giantswarm.io/pause-reason-": "",
+						"chart-operator.giantswarm.io/paused-":       "",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -1001,6 +1017,8 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
+						"chart-operator.giantswarm.io/pause-reason-": "",
+						"chart-operator.giantswarm.io/paused-":       "",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -1080,6 +1098,8 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
+						"chart-operator.giantswarm.io/pause-reason-": "",
+						"chart-operator.giantswarm.io/paused-":       "",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -1121,6 +1141,8 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
+						"chart-operator.giantswarm.io/pause-reason-": "",
+						"chart-operator.giantswarm.io/paused-":       "",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",

--- a/service/controller/app/resource/chart/desired_test.go
+++ b/service/controller/app/resource/chart/desired_test.go
@@ -114,8 +114,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason-": "",
-						"chart-operator.giantswarm.io/paused-":       "",
+						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
+						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -261,8 +261,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 						"chart-operator.giantswarm.io/app-name":           "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace":      "default",
 						"chart-operator.giantswarm.io/force-helm-upgrade": "true",
-						"chart-operator.giantswarm.io/pause-reason-":      "",
-						"chart-operator.giantswarm.io/paused-":            "",
+						"chart-operator.giantswarm.io/pause-reason":       "DELETE",
+						"chart-operator.giantswarm.io/paused":             "DELETE",
 					},
 					Name:      "my-cool-prometheus",
 					Namespace: "giantswarm",
@@ -358,8 +358,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason-": "",
-						"chart-operator.giantswarm.io/paused-":       "",
+						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
+						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -447,8 +447,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason-": "",
-						"chart-operator.giantswarm.io/paused-":       "",
+						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
+						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -529,8 +529,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "hello-world",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason-": "",
-						"chart-operator.giantswarm.io/paused-":       "",
+						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
+						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"chart-operator.giantswarm.io/version": "1.0.0",
@@ -639,8 +639,8 @@ func Test_Resource_GetDesiredState(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason-": "",
-						"chart-operator.giantswarm.io/paused-":       "",
+						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
+						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -865,8 +865,8 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason-": "",
-						"chart-operator.giantswarm.io/paused-":       "",
+						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
+						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -936,8 +936,8 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason-": "",
-						"chart-operator.giantswarm.io/paused-":       "",
+						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
+						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -1017,8 +1017,8 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason-": "",
-						"chart-operator.giantswarm.io/paused-":       "",
+						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
+						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -1098,8 +1098,8 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason-": "",
-						"chart-operator.giantswarm.io/paused-":       "",
+						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
+						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",
@@ -1141,8 +1141,8 @@ func Test_Resource_Bulid_TarballURL(t *testing.T) {
 					Annotations: map[string]string{
 						"chart-operator.giantswarm.io/app-name":      "my-cool-prometheus",
 						"chart-operator.giantswarm.io/app-namespace": "default",
-						"chart-operator.giantswarm.io/pause-reason-": "",
-						"chart-operator.giantswarm.io/paused-":       "",
+						"chart-operator.giantswarm.io/pause-reason":  "DELETE",
+						"chart-operator.giantswarm.io/paused":        "DELETE",
 					},
 					Labels: map[string]string{
 						"app":                                  "prometheus",

--- a/service/controller/app/resource/chart/resource.go
+++ b/service/controller/app/resource/chart/resource.go
@@ -150,7 +150,7 @@ func copyAnnotations(current, desired *v1alpha1.Chart) {
 
 	// Remove annotations whose key end with a "-"
 	for k, v := range desired.Annotations {
-		if v == "DELETE" {
+		if v == "DELETE" { //nolint:goconst
 			delete(desired.Annotations, k)
 		}
 	}

--- a/service/controller/app/resource/chart/resource.go
+++ b/service/controller/app/resource/chart/resource.go
@@ -142,9 +142,21 @@ func copyAnnotations(current, desired *v1alpha1.Chart) {
 			continue
 		}
 
+		if strings.HasSuffix(k, "-") {
+			continue
+		}
+
 		_, ok := desired.Annotations[k]
 		if !ok {
 			desired.Annotations[k] = currentValue
+		}
+	}
+
+	// Remove annotations whose key end with a "-"
+	for k := range desired.Annotations {
+		if strings.HasSuffix(k, "-") {
+			delete(desired.Annotations, strings.TrimSuffix(k, "-"))
+			delete(desired.Annotations, k)
 		}
 	}
 }

--- a/service/controller/app/resource/chart/resource.go
+++ b/service/controller/app/resource/chart/resource.go
@@ -142,10 +142,6 @@ func copyAnnotations(current, desired *v1alpha1.Chart) {
 			continue
 		}
 
-		if strings.HasSuffix(k, "-") {
-			continue
-		}
-
 		_, ok := desired.Annotations[k]
 		if !ok {
 			desired.Annotations[k] = currentValue
@@ -153,9 +149,8 @@ func copyAnnotations(current, desired *v1alpha1.Chart) {
 	}
 
 	// Remove annotations whose key end with a "-"
-	for k := range desired.Annotations {
-		if strings.HasSuffix(k, "-") {
-			delete(desired.Annotations, strings.TrimSuffix(k, "-"))
+	for k, v := range desired.Annotations {
+		if v == "DELETE" {
 			delete(desired.Annotations, k)
 		}
 	}

--- a/service/controller/app/resource/chart/resource.go
+++ b/service/controller/app/resource/chart/resource.go
@@ -29,6 +29,7 @@ type Config struct {
 	// Dependencies.
 	IndexCache indexcache.Interface
 	Logger     micrologger.Logger
+	CtrlClient client.Client
 
 	// Settings.
 	ChartNamespace    string
@@ -40,6 +41,7 @@ type Resource struct {
 	// Dependencies.
 	indexCache indexcache.Interface
 	logger     micrologger.Logger
+	ctrlClient client.Client
 
 	// Settings.
 	chartNamespace    string
@@ -54,6 +56,9 @@ func New(config Config) (*Resource, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
 
 	if config.ChartNamespace == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ChartNamespace must not be empty", config)
@@ -62,6 +67,7 @@ func New(config Config) (*Resource, error) {
 	r := &Resource{
 		indexCache: config.IndexCache,
 		logger:     config.Logger,
+		ctrlClient: config.CtrlClient,
 
 		chartNamespace:    config.ChartNamespace,
 		workloadClusterID: config.WorkloadClusterID,

--- a/service/controller/app/resource/chart/resource_test.go
+++ b/service/controller/app/resource/chart/resource_test.go
@@ -1,0 +1,102 @@
+package chart
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_copyAnnotations(t *testing.T) {
+	type args struct {
+		current map[string]string
+		desired map[string]string
+		result  map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "Add new annotation",
+			args: args{
+				current: map[string]string{},
+				desired: map[string]string{
+					"chart-operator.giantswarm.io/foo": "foobar",
+				},
+				result: map[string]string{
+					"chart-operator.giantswarm.io/foo": "foobar",
+				},
+			},
+		},
+		{
+			name: "Change existing annotation",
+			args: args{
+				current: map[string]string{
+					"chart-operator.giantswarm.io/foo": "foo",
+				},
+				desired: map[string]string{
+					"chart-operator.giantswarm.io/foo": "foobar",
+				},
+				result: map[string]string{
+					"chart-operator.giantswarm.io/foo": "foobar",
+				},
+			},
+		},
+		{
+			name: "Deleting existing annotation",
+			args: args{
+				current: map[string]string{
+					"chart-operator.giantswarm.io/foo": "foo",
+				},
+				desired: map[string]string{
+					"chart-operator.giantswarm.io/foo-": "",
+				},
+				result: map[string]string{},
+			},
+		},
+		{
+			name: "Deleting not owned annotation",
+			args: args{
+				current: map[string]string{
+					"foobar": "foo",
+				},
+				desired: map[string]string{},
+				result:  map[string]string{},
+			},
+		},
+		{
+			name: "Attempting to delete annotation that's not there",
+			args: args{
+				current: map[string]string{
+					"chart-operator.giantswarm.io/foo": "foo",
+				},
+				desired: map[string]string{
+					"chart-operator.giantswarm.io/bar-": "",
+				},
+				result: map[string]string{
+					"chart-operator.giantswarm.io/foo": "foo",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desired := getChart(tt.args.desired)
+			copyAnnotations(getChart(tt.args.current), desired)
+			if !reflect.DeepEqual(desired.Annotations, tt.args.result) {
+				t.Logf("Wanted %v, got %v", tt.args.result, desired.Annotations)
+				t.Fail()
+			}
+		})
+	}
+}
+
+func getChart(annotations map[string]string) *v1alpha1.Chart {
+	return &v1alpha1.Chart{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotations,
+		},
+	}
+}

--- a/service/controller/app/resource/chart/resource_test.go
+++ b/service/controller/app/resource/chart/resource_test.go
@@ -45,18 +45,6 @@ func Test_copyAnnotations(t *testing.T) {
 			},
 		},
 		{
-			name: "Deleting existing annotation",
-			args: args{
-				current: map[string]string{
-					"chart-operator.giantswarm.io/foo": "foo",
-				},
-				desired: map[string]string{
-					"chart-operator.giantswarm.io/foo": "DELETE",
-				},
-				result: map[string]string{},
-			},
-		},
-		{
 			name: "Deleting not owned annotation",
 			args: args{
 				current: map[string]string{
@@ -67,17 +55,26 @@ func Test_copyAnnotations(t *testing.T) {
 			},
 		},
 		{
-			name: "Attempting to delete annotation that's not there",
+			name: "Pause annotation is kept when not handled by app operator",
 			args: args{
 				current: map[string]string{
-					"chart-operator.giantswarm.io/foo": "foo",
+					"chart-operator.giantswarm.io/paused": "true",
 				},
-				desired: map[string]string{
-					"chart-operator.giantswarm.io/bar": "DELETE",
-				},
+				desired: map[string]string{},
 				result: map[string]string{
-					"chart-operator.giantswarm.io/foo": "foo",
+					"chart-operator.giantswarm.io/paused": "true",
 				},
+			},
+		},
+		{
+			name: "Pause annotation is deleted when handled by app operator",
+			args: args{
+				current: map[string]string{
+					"chart-operator.giantswarm.io/paused":     "true",
+					"app-operator.giantswarm.io/pause-reason": "foobar",
+				},
+				desired: map[string]string{},
+				result:  map[string]string{},
 			},
 		},
 	}

--- a/service/controller/app/resource/chart/resource_test.go
+++ b/service/controller/app/resource/chart/resource_test.go
@@ -3,12 +3,18 @@ package chart
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_copyAnnotations(t *testing.T) {
+
+	now := time.Now().Format(time.RFC3339)
+	tenminutesago := time.Now().Add(-10 * time.Minute).Format(time.RFC3339)
+	expired := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+
 	type args struct {
 		current map[string]string
 		desired map[string]string
@@ -82,15 +88,16 @@ func Test_copyAnnotations(t *testing.T) {
 			args: args{
 				current: map[string]string{
 					"chart-operator.giantswarm.io/paused":     "true",
-					"app-operator.giantswarm.io/pause-ts":     "foobar",
+					"app-operator.giantswarm.io/pause-ts":     tenminutesago,
 					"app-operator.giantswarm.io/pause-reason": "foobar",
 				},
 				desired: map[string]string{
 					"chart-operator.giantswarm.io/paused":     "true",
 					"app-operator.giantswarm.io/pause-reason": "changed",
+					"app-operator.giantswarm.io/pause-ts":     now,
 				},
 				result: map[string]string{
-					"app-operator.giantswarm.io/pause-ts":     "foobar",
+					"app-operator.giantswarm.io/pause-ts":     tenminutesago,
 					"app-operator.giantswarm.io/pause-reason": "changed",
 					"chart-operator.giantswarm.io/paused":     "true",
 				},
@@ -101,17 +108,17 @@ func Test_copyAnnotations(t *testing.T) {
 			args: args{
 				current: map[string]string{
 					"chart-operator.giantswarm.io/paused":     "true",
-					"app-operator.giantswarm.io/pause-ts":     "foobar",
+					"app-operator.giantswarm.io/pause-ts":     tenminutesago,
 					"app-operator.giantswarm.io/pause-reason": "foobar",
 				},
 				desired: map[string]string{
 					"chart-operator.giantswarm.io/paused":     "true",
-					"app-operator.giantswarm.io/pause-ts":     "changed",
+					"app-operator.giantswarm.io/pause-ts":     now,
 					"app-operator.giantswarm.io/pause-reason": "foobar",
 				},
 				result: map[string]string{
 					"chart-operator.giantswarm.io/paused":     "true",
-					"app-operator.giantswarm.io/pause-ts":     "foobar",
+					"app-operator.giantswarm.io/pause-ts":     tenminutesago,
 					"app-operator.giantswarm.io/pause-reason": "foobar",
 				},
 			},
@@ -126,11 +133,31 @@ func Test_copyAnnotations(t *testing.T) {
 				result:  map[string]string{},
 			},
 		},
+		{
+			name: "Pause annotations removed when timeout elapsed",
+			args: args{
+				current: map[string]string{
+					"chart-operator.giantswarm.io/paused":     "true",
+					"app-operator.giantswarm.io/pause-ts":     expired,
+					"app-operator.giantswarm.io/pause-reason": "foobar",
+				},
+				desired: map[string]string{
+					"chart-operator.giantswarm.io/paused":     "true",
+					"app-operator.giantswarm.io/pause-ts":     now,
+					"app-operator.giantswarm.io/pause-reason": "foobar",
+				},
+				result: map[string]string{},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			desired := getChart(tt.args.desired)
-			copyAnnotations(getChart(tt.args.current), desired)
+			r := &Resource{
+				dependencyWaitTimeoutMinutes: 30,
+			}
+
+			r.copyAnnotations(getChart(tt.args.current), desired)
 			if !reflect.DeepEqual(desired.Annotations, tt.args.result) {
 				t.Logf("Wanted %v, got %v", tt.args.result, desired.Annotations)
 				t.Fail()

--- a/service/controller/app/resource/chart/resource_test.go
+++ b/service/controller/app/resource/chart/resource_test.go
@@ -77,6 +77,55 @@ func Test_copyAnnotations(t *testing.T) {
 				result:  map[string]string{},
 			},
 		},
+		{
+			name: "Pause timestamp annotation is kept",
+			args: args{
+				current: map[string]string{
+					"chart-operator.giantswarm.io/paused":     "true",
+					"app-operator.giantswarm.io/pause-ts":     "foobar",
+					"app-operator.giantswarm.io/pause-reason": "foobar",
+				},
+				desired: map[string]string{
+					"chart-operator.giantswarm.io/paused":     "true",
+					"app-operator.giantswarm.io/pause-reason": "changed",
+				},
+				result: map[string]string{
+					"app-operator.giantswarm.io/pause-ts":     "foobar",
+					"app-operator.giantswarm.io/pause-reason": "changed",
+					"chart-operator.giantswarm.io/paused":     "true",
+				},
+			},
+		},
+		{
+			name: "Pause timestamp annotation is unchanged",
+			args: args{
+				current: map[string]string{
+					"chart-operator.giantswarm.io/paused":     "true",
+					"app-operator.giantswarm.io/pause-ts":     "foobar",
+					"app-operator.giantswarm.io/pause-reason": "foobar",
+				},
+				desired: map[string]string{
+					"chart-operator.giantswarm.io/paused":     "true",
+					"app-operator.giantswarm.io/pause-ts":     "changed",
+					"app-operator.giantswarm.io/pause-reason": "foobar",
+				},
+				result: map[string]string{
+					"chart-operator.giantswarm.io/paused":     "true",
+					"app-operator.giantswarm.io/pause-ts":     "foobar",
+					"app-operator.giantswarm.io/pause-reason": "foobar",
+				},
+			},
+		},
+		{
+			name: "Pause timestamp annotation is deleted when pause is removed",
+			args: args{
+				current: map[string]string{
+					"app-operator.giantswarm.io/pause-ts": "foobar",
+				},
+				desired: map[string]string{},
+				result:  map[string]string{},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/service/controller/app/resource/chart/resource_test.go
+++ b/service/controller/app/resource/chart/resource_test.go
@@ -51,7 +51,7 @@ func Test_copyAnnotations(t *testing.T) {
 					"chart-operator.giantswarm.io/foo": "foo",
 				},
 				desired: map[string]string{
-					"chart-operator.giantswarm.io/foo-": "",
+					"chart-operator.giantswarm.io/foo": "DELETE",
 				},
 				result: map[string]string{},
 			},
@@ -73,7 +73,7 @@ func Test_copyAnnotations(t *testing.T) {
 					"chart-operator.giantswarm.io/foo": "foo",
 				},
 				desired: map[string]string{
-					"chart-operator.giantswarm.io/bar-": "",
+					"chart-operator.giantswarm.io/bar": "DELETE",
 				},
 				result: map[string]string{
 					"chart-operator.giantswarm.io/foo": "foo",

--- a/service/controller/app/resource/chart/update.go
+++ b/service/controller/app/resource/chart/update.go
@@ -81,7 +81,7 @@ func (r *Resource) newUpdateChange(ctx context.Context, currentResource, desired
 	// Copy current chart CR and annotations keeping only the values we need
 	// for comparing them.
 	currentChart = copyChart(currentChart)
-	copyAnnotations(currentChart, desiredChart)
+	r.copyAnnotations(currentChart, desiredChart)
 
 	if !reflect.DeepEqual(currentChart, desiredChart) {
 		if diff := cmp.Diff(currentChart, desiredChart); diff != "" {

--- a/service/controller/app/resource/chart/update_test.go
+++ b/service/controller/app/resource/chart/update_test.go
@@ -268,7 +268,8 @@ func Test_Resource_newUpdateChange(t *testing.T) {
 				Logger:     microloggertest.New(),
 				CtrlClient: fake.NewFakeClient(), //nolint:staticcheck
 
-				ChartNamespace: "giantswarm",
+				ChartNamespace:               "giantswarm",
+				DependencyWaitTimeoutMinutes: 30,
 			}
 			r, err := New(c)
 			if err != nil {

--- a/service/controller/app/resource/chart/update_test.go
+++ b/service/controller/app/resource/chart/update_test.go
@@ -266,6 +266,7 @@ func Test_Resource_newUpdateChange(t *testing.T) {
 			c := Config{
 				IndexCache: indexcachetest.New(indexcachetest.Config{}),
 				Logger:     microloggertest.New(),
+				CtrlClient: fake.NewFakeClient(), //nolint:staticcheck
 
 				ChartNamespace: "giantswarm",
 			}

--- a/service/controller/app/resources.go
+++ b/service/controller/app/resources.go
@@ -157,6 +157,7 @@ func newAppResources(config appResourcesConfig) ([]resource.Interface, error) {
 		c := chart.Config{
 			IndexCache: config.IndexCache,
 			Logger:     config.Logger,
+			CtrlClient: config.K8sClient.CtrlClient(),
 
 			ChartNamespace:    config.ChartNamespace,
 			WorkloadClusterID: config.WorkloadClusterID,

--- a/service/controller/app/resources.go
+++ b/service/controller/app/resources.go
@@ -39,13 +39,14 @@ type appResourcesConfig struct {
 	Logger      micrologger.Logger
 
 	// Settings.
-	ChartNamespace    string
-	HTTPClientTimeout time.Duration
-	ImageRegistry     string
-	ProjectName       string
-	Provider          string
-	UniqueApp         bool
-	WorkloadClusterID string
+	ChartNamespace               string
+	HTTPClientTimeout            time.Duration
+	ImageRegistry                string
+	ProjectName                  string
+	Provider                     string
+	UniqueApp                    bool
+	WorkloadClusterID            string
+	DependencyWaitTimeoutMinutes int
 }
 
 func newAppResources(config appResourcesConfig) ([]resource.Interface, error) {
@@ -159,8 +160,9 @@ func newAppResources(config appResourcesConfig) ([]resource.Interface, error) {
 			Logger:     config.Logger,
 			CtrlClient: config.K8sClient.CtrlClient(),
 
-			ChartNamespace:    config.ChartNamespace,
-			WorkloadClusterID: config.WorkloadClusterID,
+			ChartNamespace:               config.ChartNamespace,
+			WorkloadClusterID:            config.WorkloadClusterID,
+			DependencyWaitTimeoutMinutes: config.DependencyWaitTimeoutMinutes,
 		}
 
 		ops, err := chart.New(c)

--- a/service/service.go
+++ b/service/service.go
@@ -125,15 +125,16 @@ func New(config Config) (*Service, error) {
 			Logger:      config.Logger,
 			K8sClient:   config.K8sClient,
 
-			ChartNamespace:    config.Viper.GetString(config.Flag.Service.Chart.Namespace),
-			HTTPClientTimeout: config.Viper.GetDuration(config.Flag.Service.Helm.HTTP.ClientTimeout),
-			ImageRegistry:     config.Viper.GetString(config.Flag.Service.Image.Registry),
-			PodNamespace:      podNamespace,
-			Provider:          config.Viper.GetString(config.Flag.Service.Provider.Kind),
-			ResyncPeriod:      config.Viper.GetDuration(config.Flag.Service.Operatorkit.ResyncPeriod),
-			UniqueApp:         config.Viper.GetBool(config.Flag.Service.App.Unique),
-			WatchNamespace:    config.Viper.GetString(config.Flag.Service.App.WatchNamespace),
-			WorkloadClusterID: config.Viper.GetString(config.Flag.Service.App.WorkloadClusterID),
+			ChartNamespace:               config.Viper.GetString(config.Flag.Service.Chart.Namespace),
+			HTTPClientTimeout:            config.Viper.GetDuration(config.Flag.Service.Helm.HTTP.ClientTimeout),
+			ImageRegistry:                config.Viper.GetString(config.Flag.Service.Image.Registry),
+			PodNamespace:                 podNamespace,
+			Provider:                     config.Viper.GetString(config.Flag.Service.Provider.Kind),
+			ResyncPeriod:                 config.Viper.GetDuration(config.Flag.Service.Operatorkit.ResyncPeriod),
+			UniqueApp:                    config.Viper.GetBool(config.Flag.Service.App.Unique),
+			WatchNamespace:               config.Viper.GetString(config.Flag.Service.App.WatchNamespace),
+			WorkloadClusterID:            config.Viper.GetString(config.Flag.Service.App.WorkloadClusterID),
+			DependencyWaitTimeoutMinutes: config.Viper.GetInt(config.Flag.Service.App.DependencyWaitTimeoutMinutes),
 		}
 
 		appController, err = app.NewApp(c)


### PR DESCRIPTION
TL;DR This PR implements a lightweight strategy for managing dependencies between apps.

# The problem

When creating workload clusters, currently apps are all installed at the same time. In the cluster, it might be that some apps are installed before others they rely upon (typical example `vertical-pod-autoscaler-app` installed before `vertical-pod-autoscaler-crd`). This can require several reconciliation loops to be fixed and can delay cluster creation by several minutes (up to 30 according to my experience).

# The proposal

With this PR I suggest adding a lightweight implementation of dependencies between apps.

Key characteristics of the change in this PR:

- dependency knowledge is provided to each app using an annotation (how that annotation gets there is outside the scope of this PR or this operator in general)
- when app-operator detects there is a dependency not installed for some app, when creating or updating the chart CR it adds the `pause` annotation so `chart-operator` does not reconcile it.
- thanks to the choice of using annotations, there is no change in the CRD
- there is a timeout feature, that removes the pause annotation even if the dependencies are not satisfied after a customizable period of time (default 30 minutes).
- if the dependency annotation is not set, app-operator behaves 100% as it was before this PR.

## Checklist

- [x] Update changelog in CHANGELOG.md.
