### PR TITLE
Disabling validation for App CR being deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Skip validation if the App CR is being deleted.
+
 ## [6.6.0] - 2023-02-02
 
 ### Added

--- a/service/controller/app/resource/validation/create.go
+++ b/service/controller/app/resource/validation/create.go
@@ -20,6 +20,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	// Return early if the app is being deleted, there is no point
+	// in validating it now.
+	if key.IsDeleted(cr) {
+		return nil
+	}
+
 	_, err = r.appValidator.ValidateApp(ctx, cr)
 	if validation.IsValidationError(err) {
 		r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("validation error %s", err.Error()))


### PR DESCRIPTION
## Description

Validating App CR on deletion does not seem necessary. This should solve one of the minor issues with the Observability App Bundle installed from the Release CRs.

Towards: https://github.com/giantswarm/giantswarm/issues/25731

## Checklist

- [x] Update changelog in CHANGELOG.md.
