### PR TITLE
add-option-to-disable-k8s-client-cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add option to disable k8s client cache.
+
 ## [6.9.0] - 2023-11-10
 
 ### Changed

--- a/flag/service/kubernetes/kubernetes.go
+++ b/flag/service/kubernetes/kubernetes.go
@@ -1,0 +1,18 @@
+package kubernetes
+
+import (
+	"github.com/giantswarm/operatorkit/v8/pkg/flag/service/kubernetes/tls"
+	"github.com/giantswarm/operatorkit/v8/pkg/flag/service/kubernetes/watch"
+)
+
+// Kubernetes is a data structure to hold Kubernetes specific command line
+// configuration flags.
+type Kubernetes struct {
+	Address            string
+	DisableClientCache string
+	InCluster          string
+	KubeConfig         string
+	KubeConfigPath     string
+	TLS                tls.TLS
+	Watch              watch.Watch
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -1,13 +1,12 @@
 package service
 
 import (
-	"github.com/giantswarm/operatorkit/v8/pkg/flag/service/kubernetes"
-
 	"github.com/giantswarm/app-operator/v6/flag/service/app"
 	"github.com/giantswarm/app-operator/v6/flag/service/appcatalog"
 	"github.com/giantswarm/app-operator/v6/flag/service/chart"
 	"github.com/giantswarm/app-operator/v6/flag/service/helm"
 	"github.com/giantswarm/app-operator/v6/flag/service/image"
+	"github.com/giantswarm/app-operator/v6/flag/service/kubernetes"
 	"github.com/giantswarm/app-operator/v6/flag/service/operatorkit"
 	"github.com/giantswarm/app-operator/v6/flag/service/provider"
 )

--- a/helm/app-operator/templates/configmap.yaml
+++ b/helm/app-operator/templates/configmap.yaml
@@ -26,6 +26,7 @@ data:
         registry: '{{ .Values.registry.domain }}'
       kubernetes:
         incluster: true
+        disableClientCache: {{ $.Values.kubernetes.disableClientCache }}
       operatorkit:
         resyncPeriod: '{{ .Values.operatorkit.resyncPeriod }}'
       provider:

--- a/helm/app-operator/values.schema.json
+++ b/helm/app-operator/values.schema.json
@@ -119,6 +119,7 @@
         "disableClientCache": {
           "type": "boolean"
         }
+      }
     },
     "name": {
       "type": "string"

--- a/helm/app-operator/values.schema.json
+++ b/helm/app-operator/values.schema.json
@@ -113,6 +113,13 @@
         }
       }
     },
+    "kubernetes": {
+      "type": "object",
+      "properties": {
+        "disableClientCache": {
+          "type": "boolean"
+        }
+    },
     "name": {
       "type": "string"
     },

--- a/helm/app-operator/values.yaml
+++ b/helm/app-operator/values.yaml
@@ -19,6 +19,9 @@ helm:
 provider:
   kind: ""
 
+kubernetes:
+  disableClientCache: false
+
 userID: 1000
 groupID: 1000
 

--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ func mainWithError() (err error) {
 	daemonCommand.PersistentFlags().String(f.Service.Helm.HTTP.ClientTimeout, "5s", "HTTP timeout for pulling chart tarballs.")
 	daemonCommand.PersistentFlags().String(f.Service.Image.Registry, "quay.io", "The container registry for pulling Tiller images.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "", "Address used to connect to Kubernetes. When empty in-cluster config is created.")
+	daemonCommand.PersistentFlags().Bool(f.Service.Kubernetes.DisableClientCache, false, "Disable Kubernetes client cache.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Kubernetes.InCluster, true, "Whether to use the in-cluster config to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.KubeConfig, "", "KubeConfig used to connect to Kubernetes. When empty other settings are used.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CAFile, "", "Certificate authority file path to use to authenticate with Kubernetes.")

--- a/service/internal/clientcache/cache.go
+++ b/service/internal/clientcache/cache.go
@@ -68,14 +68,14 @@ func New(config Config) (*Resource, error) {
 
 	r := &Resource{
 		// Dependencies.
-		cache:        gocache.New(expiration, expiration/2),
-		fs:           config.Fs,
-		k8sClient:    config.K8sClient,
-		logger:       config.Logger,
-		disableCache: config.DisableCache,
+		cache:     gocache.New(expiration, expiration/2),
+		fs:        config.Fs,
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
 
 		// Settings
 		httpClientTimeout: config.HTTPClientTimeout,
+		disableCache:      config.DisableCache,
 	}
 
 	return r, nil

--- a/service/service.go
+++ b/service/service.go
@@ -86,6 +86,7 @@ func New(config Config) (*Service, error) {
 	fs := afero.NewOsFs()
 	podNamespace := env.PodNamespace()
 
+	fmt.Printf("\nDisable cache: %t\n\n", config.Viper.GetBool(config.Flag.Service.Kubernetes.DisableClientCache))
 	var clientCache *clientcache.Resource
 	{
 		c := clientcache.Config{

--- a/service/service.go
+++ b/service/service.go
@@ -86,7 +86,6 @@ func New(config Config) (*Service, error) {
 	fs := afero.NewOsFs()
 	podNamespace := env.PodNamespace()
 
-	fmt.Printf("\nDisable cache: %t\n\n", config.Viper.GetBool(config.Flag.Service.Kubernetes.DisableClientCache))
 	var clientCache *clientcache.Resource
 	{
 		c := clientcache.Config{

--- a/service/service.go
+++ b/service/service.go
@@ -94,6 +94,7 @@ func New(config Config) (*Service, error) {
 			Logger:    config.Logger,
 
 			HTTPClientTimeout: config.Viper.GetDuration(config.Flag.Service.Helm.HTTP.ClientTimeout),
+			DisableCache:      config.Viper.GetBool(config.Flag.Service.Kubernetes.DisableClientCache),
 		}
 
 		clientCache, err = clientcache.New(c)


### PR DESCRIPTION
the client cache does not work for EKS as the kubeconfig is pretty short-lived (around 10-15 minutes) and the caching interval is 10 minutes as well so if the app-operator  caches the kubeconfig very close to the EKS kubeconfig expiration then there is a situation that the app operator cannot work for several minutes, in E2E CI its around 5-8 minutes, this breaks e2e for EKS

towards https://github.com/giantswarm/roadmap/issues/2820

I assume same thing affect the imported EKS clusters