### PR TITLE
Add policy exception so that controller can be deployed in bootstrap mode (uses host network)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Add policy exception so that controller can be deployed in bootstrap mode (uses host network)
+
 ## [6.10.0] - 2023-11-15
 
 ### Added

--- a/helm/app-operator/templates/policyexception.yaml
+++ b/helm/app-operator/templates/policyexception.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.kyvernoPolicyExceptions.enabled }}
+{{- if .Values.bootstrapMode.enabled }}
+{{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
+apiVersion: kyverno.io/v2alpha1
+kind: PolicyException
+metadata:
+  name: {{ include "resource.default.name" . }}-bootstrap-mode
+  namespace: {{ include "resource.default.namespace" . }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+spec:
+  exceptions:
+    - policyName: disallow-host-namespaces
+      ruleNames:
+        - autogen-host-namespaces
+        - host-namespaces
+  match:
+    any:
+    - resources:
+        kinds:
+          - Deployment
+          - ReplicaSet
+          - Pod
+        namespaces:
+          - {{ include "resource.default.namespace" . }}
+        names:
+          - "{{ include "resource.default.name" . }}*"
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/app-operator/values.yaml
+++ b/helm/app-operator/values.yaml
@@ -99,3 +99,6 @@ serviceMonitor:
 
 podSecurityStandards:
   enforced: false
+
+kyvernoPolicyExceptions:
+  enabled: true


### PR DESCRIPTION
I found app-operator to fail installation during MC creation, during which we use bootstrap mode (and thus the host network which is disallowed by default Kyverno policies). I'm using a very similar solution to https://github.com/giantswarm/chart-operator/blob/master/helm/chart-operator/templates/policy-exceptions.yaml. Successfully tested manually by continuing the `mc-bootstrap` MC creation procedure with app-operator version overridden with my change and the test catalog.

## Checklist

- [x] Update changelog in CHANGELOG.md.
