### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.35.1
+  architect: giantswarm/architect@4.35.3
 
 workflows:
   build:
@@ -13,42 +13,12 @@ workflows:
             tags:
               only: /^v.*/
 
-      - architect/push-to-docker:
-          context: "architect"
-          name: push-app-operator-to-docker
-          image: "docker.io/giantswarm/app-operator"
-          username_envar: "DOCKER_USERNAME"
-          password_envar: "DOCKER_PASSWORD"
-          requires:
-            - go-build
-          # Needed to trigger job also on git tag.
-          filters:
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-docker:
+      - architect/push-to-registries:
           context: architect
-          name: push-app-operator-to-quay
-          image: "quay.io/giantswarm/app-operator"
-          username_envar: "QUAY_USERNAME"
-          password_envar: "QUAY_PASSWORD"
+          name: push-to-registries
           requires:
             - go-build
           filters:
-            # Trigger the job also on git tag.
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-docker:
-          context: architect
-          name: push-app-operator-to-aliyun
-          image: "giantswarm-registry.cn-shanghai.cr.aliyuncs.com/giantswarm/app-operator"
-          username_envar: "ALIYUN_USERNAME"
-          password_envar: "ALIYUN_PASSWORD"
-          requires:
-            - go-build
-          filters:
-            # Trigger the job also on git tag.
             tags:
               only: /^v.*/
 
@@ -59,7 +29,7 @@ workflows:
           app_catalog_test: "control-plane-test-catalog"
           chart: "app-operator"
           requires:
-            - push-app-operator-to-quay
+            - push-to-registries
           filters:
             tags:
               only: /^v.*/
@@ -107,8 +77,8 @@ workflows:
           app_name: "app-operator"
           app_collection_repo: "aws-app-collection"
           requires:
-            - push-app-operator-to-aliyun
             - push-app-operator-to-control-plane-app-catalog
+            - push-to-registries
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2915

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is only one CI job for all registry pushes, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- update the changelog if you think this deserves a mention.
- approve and merge this PR once it's ready. No need to wait for the author in this case.