### PR TITLE
fix: bump appcatalog to v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
   `gsoci`, and is absent from 9.x. 9.6.0 is the version already running in `coredns-app`,
   `external-dns-app` and `kyverno-policies-dx`.
 
+### Fixed
+
+- Bump `appcatalog` to v1.0.2, fixing the four integration-test jobs. `integration/setup/setup.go`
+  resolves the chart under test with `appcatalog.GetLatestChart(..., key.AppOperatorInTestVersion())`,
+  which returns `env.CircleSHA()` for development builds, and appcatalog matched the index entry with
+  `strings.HasSuffix(entry.Version, appVersion)`. That worked while architect published charts as
+  `<version>-<full 40 character SHA>` -- the assumption `integration/key/key.go` still documents -- but
+  the orb bump above moved publishing to the gitsemver development version, whose trailing SHA is
+  abbreviated to seven characters. A full SHA can never match that by suffix, so every lookup failed
+  with `no app ... in index.yaml with given appVersion` even though the chart was published correctly.
+  appcatalog v1.0.2 accepts both formats.
+
 ## [7.5.2] - 2026-02-10
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/giantswarm/apiextensions-application v0.6.2
 	github.com/giantswarm/app/v8 v8.1.1
-	github.com/giantswarm/appcatalog v1.0.1
+	github.com/giantswarm/appcatalog v1.0.2
 	github.com/giantswarm/apptest v1.4.1
 	github.com/giantswarm/backoff v1.0.1
 	github.com/giantswarm/errors v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
 github.com/giantswarm/app/v8 v8.1.1 h1:kS9Ma++OBVyODEzYiGA6JcYNOCxuAxu17VpYneIzyIA=
 github.com/giantswarm/app/v8 v8.1.1/go.mod h1:TUwvutQSqcs43FUsoSHlcIS87aqhYyJ2uunbf5Hbb1E=
-github.com/giantswarm/appcatalog v1.0.1 h1:hUBN5CTGbfMYiO28XihSf7kUnnPguTLOBr9BAtqfKK4=
-github.com/giantswarm/appcatalog v1.0.1/go.mod h1:mL+OaULPRgdnf91Vws1pmyvqVxx16t89s4kDF/O/ps0=
+github.com/giantswarm/appcatalog v1.0.2 h1:1k2iiQ60atiIP1TzKMpCxyK9mTMcX3Dk16NoenDK/VA=
+github.com/giantswarm/appcatalog v1.0.2/go.mod h1:22bcRghWPjOuZ60KY46DoOI85YinTEaCQROJVF1C+iQ=
 github.com/giantswarm/apptest v1.4.1 h1:9GEVbB8Zvb/EdRXcmc2zWebs0TQ4pZrJ7W5XjnpDJS8=
 github.com/giantswarm/apptest v1.4.1/go.mod h1:JvH9J9BP/tgYot+WQIv6ATjetOt0bkjxWbDf/DnkVCg=
 github.com/giantswarm/backoff v1.0.1 h1:paqQhjUsibkf+wWFCHsk7VXAkcM1L3ssAe7V7i8twpM=


### PR DESCRIPTION
### Why

All four integration-test jobs (`appcatalogentry-`, `basic-`, `watching-configmap-`,
`workload-cluster-`) have failed since the architect orb went 6.15.0 → 9.6.0.

`integration/setup/setup.go` resolves the chart under test with:

```go
appcatalog.GetLatestChart(ctx, key.ControlPlaneTestCatalogStorageURL(), project.Name(), key.AppOperatorInTestVersion())
```

`AppOperatorInTestVersion()` returns `env.CircleSHA()` for development builds. `appcatalog` selected the
index entry with `strings.HasSuffix(entry.Version, appVersion)`, which matched while architect published
charts as `<version>-<full 40 character SHA>`. `integration/key/key.go` still documents exactly that
assumption:

```go
// In case of running the tests against a development version, the artifact is uploaded to the test
// catalog with the SHA1 postfixed to the version, e.g. app-operator-5.11.0-19b12a1e...tgz
```

Orb 9.x publishes the gitsemver development version instead, whose trailing SHA is abbreviated to
**seven** characters — so a full SHA can never match by suffix, and every lookup fails with
`no app ... in index.yaml with given appVersion` even though the chart was published correctly.

[appcatalog#303](https://github.com/giantswarm/appcatalog/pull/303), released as **v1.0.2**, accepts
both formats.

### What changed

`go get github.com/giantswarm/appcatalog@v1.0.2` plus `go mod tidy` — only `go.mod` and `go.sum`
change. `go build ./...` passes.

### Note

The comment quoted above is now stale in spirit — it describes only the old format. Left as-is to keep
this a pure dependency bump; worth a follow-up tidy.

Same bump is going to `chart-operator` and `apptest`. This is what Renovate would raise anyway; opening
it directly so the integration tests stop being red in the meantime.